### PR TITLE
More user friendly FileListView system

### DIFF
--- a/app_pojavlauncher/src/main/java/com/kdt/pickafile/FileListView.java
+++ b/app_pojavlauncher/src/main/java/com/kdt/pickafile/FileListView.java
@@ -24,17 +24,31 @@ public class FileListView extends LinearLayout
     private AlertDialog build;
     private String lockPath = "/";
 
+    //For filtering by file types:
+    private final String[] fileSuffixes;
+
     public FileListView(AlertDialog build) {
-        this(build.getContext(), null);
+        this(build.getContext(), null, new String[0]);
         this.build = build;
     }
 
-    public FileListView(Context context, AttributeSet attrs) {
-        this(context, attrs, 0);
+    public FileListView(AlertDialog build, String fileSuffix) {
+        this(build.getContext(), null, new String[]{fileSuffix});
+        this.build = build;
     }
 
-    public FileListView(Context context, AttributeSet attrs, int defStyle) {
+    public FileListView(AlertDialog build, String[] fileSuffixes){
+        this(build.getContext(), null, fileSuffixes);
+        this.build = build;
+    }
+
+    public FileListView(Context context, AttributeSet attrs, String[] fileSuffixes) {
+        this(context, attrs, 0, fileSuffixes);
+    }
+
+    public FileListView(Context context, AttributeSet attrs, int defStyle, String[] fileSuffixes) {
         super(context, attrs, defStyle);
+        this.fileSuffixes = fileSuffixes;
         init(context);
     }
 
@@ -84,6 +98,7 @@ public class FileListView extends LinearLayout
     {
         this.listener = listener;
     }
+
     public void listFileAt(final String path)
     {
         try{
@@ -101,9 +116,26 @@ public class FileListView extends LinearLayout
 
                     if(listFile.length != 0){
                         Arrays.sort(listFile, new SortFileName());
-                        for(File file : listFile){
-                            fileAdapter.add(file);
+                        if(fileSuffixes.length > 0){ //Meaning we want only specific files
+                            for(File file : listFile){
+                                if(file.isDirectory()){
+                                    fileAdapter.add(file);
+                                    continue;
+                                }
+
+                                for(String suffix : fileSuffixes){
+                                    if(file.getName().endsWith("." + suffix)){
+                                        fileAdapter.add(file);
+                                        break;
+                                    }
+                                }
+                            }
+                        }else{ //We get every file
+                            for(File file : listFile){
+                                fileAdapter.add(file);
+                            }
                         }
+
                     }
                     mainLv.setAdapter(fileAdapter);
                     if (build != null) build.setTitle(new File(path).getName());

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/BaseLauncherActivity.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/BaseLauncherActivity.java
@@ -124,16 +124,15 @@ public abstract class BaseLauncherActivity extends BaseActivity {
             dialog.setView(edit);
         } else {
             dialog = builder.create();
-            FileListView flv = new FileListView(dialog);
+            FileListView flv = new FileListView(dialog,"jar");
             flv.setFileSelectedListener(new FileSelectedListener(){
                     @Override
                     public void onFileSelected(File file, String path) {
-                        if (file.getName().endsWith(".jar")) {
-                            Intent intent = new Intent(BaseLauncherActivity.this, JavaGUILauncherActivity.class);
-                            intent.putExtra("modFile", file);
-                            startActivity(intent);
-                            dialog.dismiss();
-                        }
+                        Intent intent = new Intent(BaseLauncherActivity.this, JavaGUILauncherActivity.class);
+                        intent.putExtra("modFile", file);
+                        startActivity(intent);
+                        dialog.dismiss();
+
                     }
                 });
             dialog.setView(flv);

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/CustomControlsActivity.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/CustomControlsActivity.java
@@ -100,16 +100,14 @@ public class CustomControlsActivity extends BaseActivity
 		builder.setPositiveButton(android.R.string.cancel, null);
 
 		final AlertDialog dialog = builder.create();
-		FileListView flv = new FileListView(dialog);
+		FileListView flv = new FileListView(dialog, "json");
 		flv.lockPathAt(Tools.CTRLMAP_PATH);
 		flv.setFileSelectedListener(new FileSelectedListener(){
 
 				@Override
 				public void onFileSelected(File file, String path) {
-					if (file.getName().endsWith(".json")) {
-						setDefaultControlJson(path);
-						dialog.dismiss();
-					}
+					setDefaultControlJson(path);
+					dialog.dismiss();
 				}
 			});
 		dialog.setView(flv);
@@ -182,16 +180,14 @@ public class CustomControlsActivity extends BaseActivity
 		builder.setPositiveButton(android.R.string.cancel, null);
 
 		final AlertDialog dialog = builder.create();
-		FileListView flv = new FileListView(dialog);
+		FileListView flv = new FileListView(dialog, "json");
 		flv.listFileAt(Tools.CTRLMAP_PATH);
 		flv.setFileSelectedListener(new FileSelectedListener(){
 
 				@Override
 				public void onFileSelected(File file, String path) {
-					if (file.getName().endsWith(".json")) {
-						loadControl(path);
-						dialog.dismiss();
-					}
+					loadControl(path);
+					dialog.dismiss();
 				}
 			});
 		dialog.setView(flv);

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/PojavLoginActivity.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/PojavLoginActivity.java
@@ -481,19 +481,18 @@ public class PojavLoginActivity extends BaseActivity
                 builder.setCancelable(false);
 
                 final AlertDialog dialog = builder.create();
-                FileListView flv = new FileListView(dialog);
+                FileListView flv = new FileListView(dialog, "tar.xz");
                 flv.setFileSelectedListener(new FileSelectedListener(){
 
                         @Override
                         public void onFileSelected(File file, String path) {
-                            if (file.getName().endsWith(".tar.xz")) {
-                                selectedFile.append(path);
-                                dialog.dismiss();
-                                
-                                synchronized (mLockSelectJRE) {
-                                    mLockSelectJRE.notifyAll();
-                                }
+                            selectedFile.append(path);
+                            dialog.dismiss();
+
+                            synchronized (mLockSelectJRE) {
+                                mLockSelectJRE.notifyAll();
                             }
+
                         }
                     });
                 dialog.setView(flv);


### PR DESCRIPTION
Since the title isn't descriptive enough, allow me to delve a little deeper into what my commits do.

It adds a file filtering system to the FileListView class, allowing us to hide files that aren't the type we want.
It also MUCH faster for the **end-user** to find file he needs.

The base system is still here if we need it, and we can look for multiple file types.

Going into my download folder BEFORE: ![unoptimized](https://user-images.githubusercontent.com/24864674/103409573-c1332000-4b67-11eb-9190-f82e5d99b544.jpg) And going into my download folder AFTER: ![optimized](https://user-images.githubusercontent.com/24864674/103409595-d445f000-4b67-11eb-9db6-766b0b68b497.jpg)
