### PR TITLE
- Quick fix for the version text in the UI v2

### DIFF
--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/PojavLauncherActivity.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/PojavLauncherActivity.java
@@ -88,6 +88,9 @@ public class PojavLauncherActivity extends BaseLauncherActivity
         tvUsernameView = (TextView) findViewById(R.id.launchermain_text_welcome);
         mTextVersion = (TextView) findViewById(R.id.launcherMainVersionView);
 
+        //The following line is used to make this TextView horizontally scroll if the version name is larger than the view
+        mTextVersion.setSelected(true);
+
         Tabs[0] = findViewById(R.id.btnTab1);
         Tabs[1] = findViewById(R.id.btnTab2);
         Tabs[2] = findViewById(R.id.btnTab3);

--- a/app_pojavlauncher/src/main/res/layout/launcher_main_v4.xml
+++ b/app_pojavlauncher/src/main/res/layout/launcher_main_v4.xml
@@ -273,13 +273,19 @@
 
     <TextView
         android:id="@+id/launcherMainVersionView"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="20dp"
         android:gravity="center"
         android:text="@string/global_waiting"
         android:textSize="12sp"
-        app:layout_constraintEnd_toEndOf="@+id/launchermain_text_welcome"
-        app:layout_constraintStart_toStartOf="@+id/launchermain_text_welcome"
+        android:singleLine="true"
+        android:scrollHorizontally="true"
+        android:ellipsize="marquee"
+        android:marqueeRepeatLimit="marquee_forever"
+        android:focusable="true"
+        android:focusableInTouchMode="true"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/launchermainPlayButton"
         app:layout_constraintTop_toBottomOf="@+id/launchermain_text_welcome" />
 
     <Button


### PR DESCRIPTION
I just realized that the version text can go outside of its boundaries  when the version was something like **1.7.10-FORGE1610-8888-1_7_10** instead of a vanilla version.

So now, the text horizontally scrolls instead.

https://user-images.githubusercontent.com/24864674/104094264-11a92c80-5290-11eb-9819-938d91a7d382.mp4

