### PR TITLE
Fixed improper layout sizing when selecting account

### DIFF
--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/PojavLoginActivity.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/PojavLoginActivity.java
@@ -747,7 +747,7 @@ public class PojavLoginActivity extends BaseActivity
 
         }
 
-        //The value 73 and 55 are dp numbers, converted into px in order to resize the layout.
+        //The value 73 and 56 are dp numbers, converted into px in order to resize the layout.
         accountDialog.getWindow().setLayout((int)(xScreen*0.4),(int)Math.min((yScreen*0.8), (73 + accountListLayout.getChildCount()*56)*(PojavLoginActivity.this.getResources().getDisplayMetrics().densityDpi/160f) ));
         accountDialog.getWindow().setBackgroundDrawable(new ColorDrawable(Color.TRANSPARENT));
         accountDialog.show();

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/PojavLoginActivity.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/PojavLoginActivity.java
@@ -737,7 +737,7 @@ public class PojavLoginActivity extends BaseActivity
                             new InvalidateTokenTask(PojavLoginActivity.this).execute(selectedAccName);
                             accountListLayout.removeViewsInLayout(0,1);
                             //Resize the window
-                            accountDialog.getWindow().setLayout((int)(xScreen*0.4),(int)Math.min((yScreen*0.8), 200 + accountListLayout.getChildCount()*150));
+                            accountDialog.getWindow().setLayout((int)(xScreen*0.4),(int) Math.min((yScreen*0.8), (73 + accountListLayout.getChildCount()*55)*(PojavLoginActivity.this.getResources().getDisplayMetrics().densityDpi/160f) ));
                         }
                     });
                     builder2.setNegativeButton(android.R.string.cancel, null);
@@ -747,7 +747,8 @@ public class PojavLoginActivity extends BaseActivity
 
         }
 
-        accountDialog.getWindow().setLayout((int)(xScreen*0.4),(int)Math.min((yScreen*0.8), 200 + accountListLayout.getChildCount()*150));
+        //The value 73 and 55 are dp numbers, converted into px in order to resize the layout.
+        accountDialog.getWindow().setLayout((int)(xScreen*0.4),(int)Math.min((yScreen*0.8), (73 + accountListLayout.getChildCount()*56)*(PojavLoginActivity.this.getResources().getDisplayMetrics().densityDpi/160f) ));
         accountDialog.getWindow().setBackgroundDrawable(new ColorDrawable(Color.TRANSPARENT));
         accountDialog.show();
     }


### PR DESCRIPTION
Another pull request, to fix one of my mistakes.
This one aims to provide a consistent layout height when using many any device.
*However, due to the way the DPI scaling can be tweaked by the manufacturer, I can't hold claim it will solve for 100% of devices*

No screenshots for this one, as I was not able to create the bug on my phone 😅 