### PR TITLE
CustomSeekBarPreference's title is now white

### DIFF
--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/CustomSeekBarPreference.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/CustomSeekBarPreference.java
@@ -2,6 +2,7 @@ package net.kdt.pojavlaunch.prefs;
 
 import android.content.Context;
 import android.content.res.TypedArray;
+import android.graphics.Color;
 import android.util.AttributeSet;
 import android.view.View;
 import android.widget.SeekBar;
@@ -52,6 +53,9 @@ public class CustomSeekBarPreference extends SeekBarPreference {
     @Override
     public void onBindViewHolder(PreferenceViewHolder view) {
         super.onBindViewHolder(view);
+        TextView titleTextView = (TextView) view.findViewById(android.R.id.title);
+        titleTextView.setTextColor(Color.WHITE);
+
         textView = (TextView) view.findViewById(R.id.seekbar_value);
         textView.setTextAlignment(View.TEXT_ALIGNMENT_TEXT_START);
         SeekBar seekBar = (SeekBar) view.findViewById(R.id.seekbar);


### PR DESCRIPTION
Since all SeekBarPreference are affected by the bug, I can fix it easily on the CustomSeekBarPreference.

![image](https://user-images.githubusercontent.com/24864674/106444263-cdb7da80-647d-11eb-8702-caf938330af3.png)
