### PR TITLE
Hotbar live resizing capability

### DIFF
--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/BaseMainActivity.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/BaseMainActivity.java
@@ -10,7 +10,6 @@ import android.view.View.*;
 import android.view.inputmethod.*;
 import android.widget.*;
 
-import androidx.annotation.RequiresApi;
 import androidx.drawerlayout.widget.*;
 import com.google.android.material.navigation.*;
 import java.io.*;
@@ -661,7 +660,8 @@ public class BaseMainActivity extends LoggableActivity {
                         texture.setDefaultBufferSize((int)(width*scaleFactor),(int)(height*scaleFactor));
                         CallbackBridge.windowWidth = (int)(width*scaleFactor);
                         CallbackBridge.windowHeight = (int)(height*scaleFactor);
-                        //CallbackBridge.sendUpdateWindowSize((int)(width*scaleFactor),(int)(height*scaleFactor));
+
+                        //Load Minecraft options:
                         MCOptionUtils.load();
                         MCOptionUtils.set("overrideWidth", ""+CallbackBridge.windowWidth);
                         MCOptionUtils.set("overrideHeight", ""+CallbackBridge.windowHeight);
@@ -1025,7 +1025,7 @@ public class BaseMainActivity extends LoggableActivity {
     }
 
     public int mcscale(int input) {
-        return this.guiScale * input;
+        return (int)((this.guiScale * input)/scaleFactor);
     }
 
     /*
@@ -1181,15 +1181,19 @@ public class BaseMainActivity extends LoggableActivity {
 
     public int handleGuiBar(int x, int y) {
         if (!CallbackBridge.isGrabbing()) return -1;
-        
-        int barheight = mcscale(20);
-        int barwidth = mcscale(180);
-        int barx = (CallbackBridge.physicalWidth / 2) - (barwidth / 2);
-        int bary = CallbackBridge.physicalHeight - barheight;
-        if (x < barx || x >= barx + barwidth || y < bary || y >= bary + barheight) {
+
+        int mcGuiScale = Integer.parseInt(MCOptionUtils.get("guiScale"));
+        if(mcGuiScale == 0) mcGuiScale = (Math.min(CallbackBridge.windowHeight, CallbackBridge.windowWidth)/240);
+        mcGuiScale = Math.min(mcGuiScale, (Math.min(CallbackBridge.windowHeight, CallbackBridge.windowWidth)/240));
+
+        int barHeight = mcscale(5 * mcGuiScale);
+        int barWidth = mcscale(45 * mcGuiScale);
+        int barX = (CallbackBridge.physicalWidth / 2) - (barWidth / 2);
+        int barY = CallbackBridge.physicalHeight - barHeight;
+        if (x < barX || x >= barX + barWidth || y < barY || y >= barY + barHeight) {
             return -1;
         }
-        return hotbarKeys[((x - barx) / mcscale(180 / 9)) % 9];
+        return hotbarKeys[((x - barX) / mcscale((45 * mcGuiScale) / 9)) % 9];
     }
 /*
     public int handleGuiBar(int x, int y, MotionEvent e) {

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/BaseMainActivity.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/BaseMainActivity.java
@@ -1193,20 +1193,5 @@ public class BaseMainActivity extends LoggableActivity {
         }
         return hotbarKeys[((x - barX) / mcscale(180 / 9)) % 9];
     }
-/*
-    public int handleGuiBar(int x, int y, MotionEvent e) {
-        if (!CallbackBridge.isGrabbing()) {
-            return -1;
-        }
 
-        // int screenHeight = CallbackBridge.windowHeight;
-        int barheight = mcscale(20);
-        int barwidth = mcscale(180);
-        int barx = (CallbackBridge.windowWidth / 2) - (barwidth / 2);
-        if (x < barx || x >= barx + barwidth || y < 0 || y >= 0 + barheight) {
-            return -1;
-        }
-        return hotbarKeys[((x - barx) / mcscale(20)) % 9];
-    }
-*/
 }

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/BaseMainActivity.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/BaseMainActivity.java
@@ -1173,7 +1173,9 @@ public class BaseMainActivity extends LoggableActivity {
 
     public void getMcScale() {
         //Get the scale stored in game files, used auto scale if found or if the stored scaled is bigger than the authorized size.
-        this.guiScale = Integer.parseInt(MCOptionUtils.get("guiScale"));
+        String str = MCOptionUtils.get("guiScale");
+        this.guiScale = (str == null ? 0 :Integer.parseInt(str));
+        
 
         int scale = Math.max(Math.min(CallbackBridge.windowWidth / 320, CallbackBridge.windowHeight / 240), 1);
         if(scale < this.guiScale || guiScale == 0){

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/BaseMainActivity.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/BaseMainActivity.java
@@ -666,7 +666,7 @@ public class BaseMainActivity extends LoggableActivity {
                         MCOptionUtils.set("overrideWidth", ""+CallbackBridge.windowWidth);
                         MCOptionUtils.set("overrideHeight", ""+CallbackBridge.windowHeight);
                         MCOptionUtils.save();
-                        calculateMcScale();
+                        getMcScale();
                         // Should we do that?
                         if (!isCalled) {
                             isCalled = true;
@@ -698,7 +698,7 @@ public class BaseMainActivity extends LoggableActivity {
                         CallbackBridge.windowWidth = (int)(width*scaleFactor);
                         CallbackBridge.windowHeight = (int)(height*scaleFactor);
                         CallbackBridge.sendUpdateWindowSize((int)(width*scaleFactor),(int)(height*scaleFactor));
-                        calculateMcScale();
+                        getMcScale();
                     }
 
                     @Override
@@ -1171,29 +1171,27 @@ public class BaseMainActivity extends LoggableActivity {
         return true;
     }
 
-    public void calculateMcScale() {
-        int scale = 1;
-        while (CallbackBridge.physicalWidth / (scale + 1) >= 320 && CallbackBridge.physicalHeight / (scale + 1) >= 240) {
-            scale++;
+    public void getMcScale() {
+        //Get the scale stored in game files, used auto scale if found or if the stored scaled is bigger than the authorized size.
+        this.guiScale = Integer.parseInt(MCOptionUtils.get("guiScale"));
+
+        int scale = Math.max(Math.min(CallbackBridge.windowWidth / 320, CallbackBridge.windowHeight / 240), 1);
+        if(scale < this.guiScale || guiScale == 0){
+            this.guiScale = scale;
         }
-        this.guiScale = scale;
     }
 
     public int handleGuiBar(int x, int y) {
         if (!CallbackBridge.isGrabbing()) return -1;
 
-        int mcGuiScale = Integer.parseInt(MCOptionUtils.get("guiScale"));
-        if(mcGuiScale == 0) mcGuiScale = (Math.min(CallbackBridge.windowHeight, CallbackBridge.windowWidth)/240);
-        mcGuiScale = Math.min(mcGuiScale, (Math.min(CallbackBridge.windowHeight, CallbackBridge.windowWidth)/240));
-
-        int barHeight = mcscale(5 * mcGuiScale);
-        int barWidth = mcscale(45 * mcGuiScale);
+        int barHeight = mcscale(20);
+        int barWidth = mcscale(180);
         int barX = (CallbackBridge.physicalWidth / 2) - (barWidth / 2);
         int barY = CallbackBridge.physicalHeight - barHeight;
         if (x < barX || x >= barX + barWidth || y < barY || y >= barY + barHeight) {
             return -1;
         }
-        return hotbarKeys[((x - barX) / mcscale((45 * mcGuiScale) / 9)) % 9];
+        return hotbarKeys[((x - barX) / mcscale(180 / 9)) % 9];
     }
 /*
     public int handleGuiBar(int x, int y, MotionEvent e) {

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MainActivity.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MainActivity.java
@@ -4,8 +4,13 @@ import android.os.*;
 import android.view.*;
 import android.view.View.*;
 import android.widget.*;
+
+import androidx.annotation.Nullable;
+
 import net.kdt.pojavlaunch.customcontrols.*;
 import net.kdt.pojavlaunch.prefs.*;
+import net.kdt.pojavlaunch.utils.MCOptionUtils;
+
 import org.lwjgl.glfw.*;
 import java.io.*;
 import com.google.gson.*;
@@ -17,6 +22,7 @@ public class MainActivity extends BaseMainActivity {
     
     private View.OnClickListener mClickListener;
     private View.OnTouchListener mTouchListener;
+    private FileObserver fileObserver;
     
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -98,6 +104,16 @@ public class MainActivity extends BaseMainActivity {
                 return false;
             }
         };
+
+
+        fileObserver = new FileObserver(new File(Tools.DIR_GAME_NEW + "/options.txt"), FileObserver.MODIFY) {
+            @Override
+            public void onEvent(int i, @Nullable String s) {
+                //FIXME Make sure the multithreading nature of this event doesn't cause any problems ?
+                MCOptionUtils.load();
+            }
+        };
+        fileObserver.startWatching();
         
         ControlData[] specialButtons = ControlData.getSpecialButtons();
         specialButtons[0].specialButtonListener

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MainActivity.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MainActivity.java
@@ -105,7 +105,7 @@ public class MainActivity extends BaseMainActivity {
             }
         };
 
-        if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.P){
+        if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q){
             fileObserver = new FileObserver(new File(Tools.DIR_GAME_NEW + "/options.txt"), FileObserver.MODIFY) {
                 @Override
                 public void onEvent(int i, @Nullable String s) {

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MainActivity.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MainActivity.java
@@ -111,6 +111,7 @@ public class MainActivity extends BaseMainActivity {
             public void onEvent(int i, @Nullable String s) {
                 //FIXME Make sure the multithreading nature of this event doesn't cause any problems ?
                 MCOptionUtils.load();
+                getMcScale();
             }
         };
         fileObserver.startWatching();

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MainActivity.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MainActivity.java
@@ -105,15 +105,26 @@ public class MainActivity extends BaseMainActivity {
             }
         };
 
+        if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.P){
+            fileObserver = new FileObserver(new File(Tools.DIR_GAME_NEW + "/options.txt"), FileObserver.MODIFY) {
+                @Override
+                public void onEvent(int i, @Nullable String s) {
+                    //FIXME Make sure the multithreading nature of this event doesn't cause any problems ?
+                    MCOptionUtils.load();
+                    getMcScale();
+                }
+            };
+        }else{
+            fileObserver = new FileObserver(Tools.DIR_GAME_NEW + "/options.txt", FileObserver.MODIFY) {
+                @Override
+                public void onEvent(int i, @Nullable String s) {
+                    //FIXME Make sure the multithreading nature of this event doesn't cause any problems ?
+                    MCOptionUtils.load();
+                    getMcScale();
+                }
+            };
+        }
 
-        fileObserver = new FileObserver(new File(Tools.DIR_GAME_NEW + "/options.txt"), FileObserver.MODIFY) {
-            @Override
-            public void onEvent(int i, @Nullable String s) {
-                //FIXME Make sure the multithreading nature of this event doesn't cause any problems ?
-                MCOptionUtils.load();
-                getMcScale();
-            }
-        };
         fileObserver.startWatching();
         
         ControlData[] specialButtons = ControlData.getSpecialButtons();

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/MCOptionUtils.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/MCOptionUtils.java
@@ -41,6 +41,9 @@ public class MCOptionUtils
     }
 
     public static String get(String key){
+        if (mLineList == null){
+            load();
+        }
         for (int i = 0; i < mLineList.size(); i++) {
             String line = mLineList.get(i);
             if (line.startsWith(key + ":")) {

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/MCOptionUtils.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/MCOptionUtils.java
@@ -39,6 +39,17 @@ public class MCOptionUtils
         
         mLineList.add(key + ":" + value);
     }
+
+    public static String get(String key){
+        for (int i = 0; i < mLineList.size(); i++) {
+            String line = mLineList.get(i);
+            if (line.startsWith(key + ":")) {
+                String value = mLineList.get(i);
+                return value.substring(value.indexOf(":")+1);
+            }
+        }
+        return null;
+    }
     
     public static void save() {
         StringBuilder result = new StringBuilder();


### PR DESCRIPTION
**Features:**
- The hotbar is working with any GUI scale !
- It supports resizing in game !
- Supports illegal GUI settings (such as large on a 270p display)

**Fixes:**
- Fixed the hotbar size being wrongly computed when GUI scale was set to anything other than auto
- Fixed the hotbar size being wrongly computed when the resolution scaler was used.

**Miscellaneous:**
- The computeMcScale was refactored (and optimized) to getMcScale since it takes the stored scale into account now.
- You can now get a minecraft setting by the setting's name. Loads the mc settings if they have not been loaded yet.
- Works fine on split screen, should work on freeform as well.

**Limitations:**
- As for all McOptions related stuff, it only works with the new folder location, used since 3.3.1 😅 

**Videos:**
- [Working at 1080p](https://cdn.discordapp.com/attachments/749694761010724987/806632109069565953/TRIM_20210203_180250.mp4)
- [Working at 25% res from 1080p, with illegal GUI value stored in settings](https://cdn.discordapp.com/attachments/749694761010724987/806632177969528923/TRIM_20210203_215759.mp4)
- [Working in split screen mode, whatever the hell the resolution was](https://cdn.discordapp.com/attachments/749694761010724987/806632179307118602/TRIM_20210203_215713.mp4)

As usual, feel free to ask anything about this pull request !