### PR TITLE
Improvements on the bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-title: "[BUG]"
+title: "[BUG] <Short description>"
 labels: bug
 assignees: ''
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -17,23 +17,34 @@ If you don't fill in this template, this issue will be marked as invalid and clo
 - Make sure you have filled this issue template, or this will get rejected.
 </details>
 
-**Describe the bug**
+### Describe the bug
 A clear and concise description of what the bug is.
 
-**To Reproduce**
-Steps to reproduce the behavior:
-1. Start PojavLauncher
-...
+**Add a log file if you want to see your bug fixed !**
 
-**Expected behavior**
+The log file called *lastlog.txt* is located under "*games/PojavLauncher/.minecraft*" .
+You may need to activate an option in your file explorer to see hidden files and folders.
+
+Do NOT paste the whole log text ! Instead, add it as a file on this issue.
+
+### To Reproduce:
+Indicate steps to reproduce the buggy behavior:
+
+1. Start PojavLauncher
+... *(your set of actions to reproduce the bug)*
+
+### Expected behavior:
 I expected ...
 
-**Screenshots**
+### Screenshots or videos:
+*Upload here screenshots or videos of the buggy behavior, if possible.*
 
 **Platform:**
  - Device Model [e.g. Mi 8 Pro 8/128]
  - CPU architecture [e.g. aarch64] 
  - Android Version [e.g. 10]
+ - PojavLauncher Version [e.g Latest Release || version 3.3.1.1_rel_20210206 ]
+
 
 <details> <summary><b>Additional context</b></summary>
 <br>


### PR DESCRIPTION
I made use of the markdown syntax to make titles a bit clearer.
I also added the requirement to attach a log file and where it is located.

This should hopefully avoid the usual request for the logfile.