### PR TITLE
Revision of .apk versioning

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -15,6 +15,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     
     - name: get Git
       run: sudo apt-get install -q -y git

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -15,10 +15,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    
-    - name: Fetch tags
-      run: git fetch origin 'refs/tags/*:refs/tags/*'
-      shell: bash
+      with:
+        fetch-depth: 0
 
     - name: set up JDK 1.8
       uses: actions/setup-java@v1

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -15,6 +15,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    
+    - name: get Git
+      run: sudo apt-get install -q -y git
+      shell: bash
 
     - name: set up JDK 1.8
       uses: actions/setup-java@v1

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -15,11 +15,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
     
-    - name: get Git
-      run: sudo apt-get install -q -y git
+    - name: Fetch tags
+      run: git fetch 'refs/tags/*:refs/tags/*'
       shell: bash
 
     - name: set up JDK 1.8

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@v2
     
     - name: Fetch tags
-      run: git fetch 'refs/tags/*:refs/tags/*'
+      run: git fetch origin 'refs/tags/*:refs/tags/*'
       shell: bash
 
     - name: set up JDK 1.8

--- a/app_pojavlauncher/build.gradle
+++ b/app_pojavlauncher/build.gradle
@@ -52,7 +52,7 @@ android {
         minSdkVersion 21
         targetSdkVersion 29
         versionCode 156249
-        versionName "${getVersionName()}"
+        versionName getVersionName()
         multiDexEnabled true //important
     }
 

--- a/app_pojavlauncher/build.gradle
+++ b/app_pojavlauncher/build.gradle
@@ -1,7 +1,13 @@
 apply plugin: 'com.android.application'
 
-def getDate() {
-    return new Date().format('yyyyMMdd')
+def getVersionName = {
+    // Get the last version tag, as well as the short head of the last commit
+    def stdout = new ByteArrayOutputStream()
+    exec {
+        commandLine 'git', 'describe', '--tags'
+        standardOutput = stdout
+    }
+    return stdout.toString().trim()
 }
 
 android {
@@ -28,7 +34,7 @@ android {
         minSdkVersion 21
         targetSdkVersion 29
         versionCode 156249
-        versionName "3.3.1.1_rel_" + getDate()
+        versionName "${getVersionName()}"
         multiDexEnabled true //important
     }
 

--- a/app_pojavlauncher/build.gradle
+++ b/app_pojavlauncher/build.gradle
@@ -1,11 +1,19 @@
 apply plugin: 'com.android.application'
 
+def getDate() { return new Date().format('yyyyMMdd')}
+
 def getVersionName = {
     // Get the last version tag, as well as the short head of the last commit
     def stdout = new ByteArrayOutputStream()
     exec {
-        commandLine 'git', 'describe', '--tags'
-        standardOutput = stdout
+        try {
+            commandLine 'git', 'describe', '--tags'
+            standardOutput = stdout
+        }catch(Exception e){
+            stdout.write("no-git-" + "${getDate()}");
+        }
+
+
     }
     return stdout.toString().trim().replace("-g", "-")
 }

--- a/app_pojavlauncher/build.gradle
+++ b/app_pojavlauncher/build.gradle
@@ -6,9 +6,11 @@ def getVersionName = {
     // Get the last version tag, as well as the short head of the last commit
     def stdout = new ByteArrayOutputStream()
     exec {
-        commandLine 'git', 'describe', '--tags'
-        ignoreExitValue true
-        standardOutput = stdout
+        try {
+            commandLine 'git', 'describe', '--tags'
+            ignoreExitValue true
+            standardOutput = stdout
+        }catch(Exception e){}
     }
     if(stdout.toString() == ""){
         stdout.write("no-git-" + "${getName}")

--- a/app_pojavlauncher/build.gradle
+++ b/app_pojavlauncher/build.gradle
@@ -4,17 +4,22 @@ def getDate() { return new Date().format('yyyyMMdd')}
 
 def getVersionName = {
     // Get the last version tag, as well as the short head of the last commit
-    def stdout = new ByteArrayOutputStream()
+    ByteArrayOutputStream TAG = new ByteArrayOutputStream()
+    ByteArrayOutputStream BRANCH = new ByteArrayOutputStream()
     exec {
-        try {
-            commandLine 'git', 'describe', '--tags'
-            standardOutput = stdout
-        }catch(Exception e){}
+        commandLine 'git', 'describe', '--tags'
+        standardOutput = TAG
     }
-    if(stdout.toString() == ""){
+    exec{
+        commandLine 'git', 'branch', '--show-current'
+        standardOutput = BRANCH
+    }
+
+    if(TAG.toString() == ""){
         return ("LOCAL-" + "${getDate()}")
     }
-    return stdout.toString().trim().replace("-g", "-")
+
+    return TAG.toString().trim().replace("-g","-") + "-" + BRANCH.toString().trim();
 }
 
 android {

--- a/app_pojavlauncher/build.gradle
+++ b/app_pojavlauncher/build.gradle
@@ -8,12 +8,11 @@ def getVersionName = {
     exec {
         try {
             commandLine 'git', 'describe', '--tags'
-            //ignoreExitValue true
             standardOutput = stdout
         }catch(Exception e){}
     }
     if(stdout.toString() == ""){
-        return ("no-git-" + "${getDate()}")
+        return ("LOCAL-" + "${getDate()}")
     }
     return stdout.toString().trim().replace("-g", "-")
 }

--- a/app_pojavlauncher/build.gradle
+++ b/app_pojavlauncher/build.gradle
@@ -7,12 +7,18 @@ def getVersionName = {
     ByteArrayOutputStream TAG = new ByteArrayOutputStream()
     ByteArrayOutputStream BRANCH = new ByteArrayOutputStream()
     exec {
-        commandLine 'git', 'describe', '--tags'
-        standardOutput = TAG
+        try{
+            commandLine 'git', 'describe', '--tags'
+            ignoreExitValue true
+            standardOutput = TAG
+        }catch(Exception e){}
     }
     exec{
-        commandLine 'git', 'branch', '--show-current'
-        standardOutput = BRANCH
+        try{
+            commandLine 'git', 'branch', '--show-current'
+            ignoreExitValue true
+            standardOutput = BRANCH
+        }catch(Exception e){}
     }
 
     if(TAG.toString() == ""){

--- a/app_pojavlauncher/build.gradle
+++ b/app_pojavlauncher/build.gradle
@@ -8,6 +8,7 @@ def getVersionName = {
     exec {
         try {
             commandLine 'git', 'describe', '--tags'
+            ignoreExitValue true
             standardOutput = stdout
         }catch(Exception e){
             stdout.write("no-git-" + "${getDate()}");

--- a/app_pojavlauncher/build.gradle
+++ b/app_pojavlauncher/build.gradle
@@ -6,15 +6,12 @@ def getVersionName = {
     // Get the last version tag, as well as the short head of the last commit
     def stdout = new ByteArrayOutputStream()
     exec {
-        try {
-            commandLine 'git', 'describe', '--tags'
-            ignoreExitValue true
-            standardOutput = stdout
-        }catch(Exception e){
-            stdout.write("no-git-" + "${getDate()}");
-        }
-
-
+        commandLine 'git', 'describe', '--tags'
+        ignoreExitValue true
+        standardOutput = stdout
+    }
+    if(stdout.toString() == ""){
+        stdout.write("no-git-" + "${getName}")
     }
     return stdout.toString().trim().replace("-g", "-")
 }

--- a/app_pojavlauncher/build.gradle
+++ b/app_pojavlauncher/build.gradle
@@ -13,7 +13,7 @@ def getVersionName = {
         }catch(Exception e){}
     }
     if(stdout.toString() == ""){
-        stdout.write("no-git-" + "${getName}")
+        stdout.write("no-git-" + "${getDate()}")
     }
     return stdout.toString().trim().replace("-g", "-")
 }

--- a/app_pojavlauncher/build.gradle
+++ b/app_pojavlauncher/build.gradle
@@ -8,7 +8,7 @@ def getVersionName = {
     exec {
         try {
             commandLine 'git', 'describe', '--tags'
-            ignoreExitValue true
+            //ignoreExitValue true
             standardOutput = stdout
         }catch(Exception e){}
     }

--- a/app_pojavlauncher/build.gradle
+++ b/app_pojavlauncher/build.gradle
@@ -13,7 +13,7 @@ def getVersionName = {
         }catch(Exception e){}
     }
     if(stdout.toString() == ""){
-        stdout.write("no-git-" + "${getDate()}")
+        return ("no-git-" + "${getDate()}")
     }
     return stdout.toString().trim().replace("-g", "-")
 }

--- a/app_pojavlauncher/build.gradle
+++ b/app_pojavlauncher/build.gradle
@@ -7,7 +7,7 @@ def getVersionName = {
         commandLine 'git', 'describe', '--tags'
         standardOutput = stdout
     }
-    return stdout.toString().trim()
+    return stdout.toString().trim().replace("-g", "-")
 }
 
 android {


### PR DESCRIPTION
*If this PR gets merged, please squash all the commits into one as many commits don't need to be here*

### So let me tell you a story,
**a story of wasted hours for both parties.**

A few days ago, a seemingly important issue was brought to me about a new feature I've been working on.
The tester had the kindness to take the necessary steps to build my fork himself, so I took a special interest in it.
Instantly panicked at the idea that I may have broken something that shouldn't be related to my last commits,
I tried to reproduce the issue with multiples devices.
**In vain.**

After watching the bug footage that was provided to me, I hypothesized that the build used was outdated.
Sending what should be an exact copy of the build supposedly containing the bug and a few forceful tactics later,
the bug was **GONE !**

At this point, I'm fairly confident in my stance but both I and the kind tester wasted a bunch of time.
However, I will never have any definite confirmation that I was right.
*That's why this PR is here.*

**Features:**
- .apk files automatically get the latest TAG in their version name.
- .apk files automatically get the latest COMMIT SHORT HEAD in their version name.

**Removed:**
- The date is no longer present when git is installed, as it lacked relevance.

**How does the new nomenclature works ?**
[TAG]-[NUMBER_OF_COMMITS_ON_TOP]-[SHORT_HEAD_LATEST_COMMIT]-[BRANCH_NAME]
*Note:* Future play store releases should only have the tag as their version names.

**Why is this a PR ?**
I've heard many times already that Gradle version changes can be a headache due to varying compatibility.
Although I tested both on windows and Linux, with different versions of Gradle, I'm not sure how it will deal with a pc without git installed on it. 👀 

EDIT: Indeed no having git is an issue, it now fallbacks on a build named "LOCAL-YYYYMMDD".
