### PR TITLE
[V2.1] + [V2.2] Control revisions

### DIFF
--- a/app_pojavlauncher/src/main/AndroidManifest.xml
+++ b/app_pojavlauncher/src/main/AndroidManifest.xml
@@ -73,6 +73,7 @@
             android:multiprocess="true"
             android:screenOrientation="sensorLandscape"
             android:name=".MainActivity"
+            android:windowSoftInputMode="stateVisible"
             android:configChanges="keyboardHidden|orientation|screenSize|keyboard|navigation"/>
         <provider
             android:name=".scoped.GameFolderProvider"

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/BaseMainActivity.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/BaseMainActivity.java
@@ -631,24 +631,23 @@ public class BaseMainActivity extends LoggableActivity {
         Toast.makeText(this, event.toString(),Toast.LENGTH_LONG).show();
         Toast.makeText(this, event.getUnicodeChar() + "",Toast.LENGTH_LONG).show();
         Toast.makeText(this, event.getDevice().toString(), Toast.LENGTH_LONG).show();
-
          */
-
 
         //Filtering useless events
         if(event.getRepeatCount() != 0
                 || event.getAction() == KeyEvent.ACTION_MULTIPLE
                 || event.getKeyCode() == KeyEvent.KEYCODE_UNKNOWN
                 || (event.getFlags() & KeyEvent.FLAG_FALLBACK) == KeyEvent.FLAG_FALLBACK) return true;
-        Toast.makeText(this, "FIRST VERIF PASSED", Toast.LENGTH_LONG).show();
+        //Toast.makeText(this, "FIRST VERIF PASSED", Toast.LENGTH_LONG).show();
 
         //Sometimes, key events comes from SOME keys of the software keyboard
         //Even weirder, is is unknown why a key or another is selected to trigger a keyEvent
         if((event.getFlags() & KeyEvent.FLAG_SOFT_KEYBOARD) == KeyEvent.FLAG_SOFT_KEYBOARD){
+            if(event.getKeyCode() == KeyEvent.KEYCODE_ENTER) return true; //We already listen to it.
             touchCharInput.dispatchKeyEvent(event);
             return true;
         }
-        Toast.makeText(this, "SECOND VERIF PASSED", Toast.LENGTH_LONG).show();
+        //Toast.makeText(this, "SECOND VERIF PASSED", Toast.LENGTH_LONG).show();
 
 
         //Sometimes, key events may come from the mouse

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/BaseMainActivity.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/BaseMainActivity.java
@@ -29,6 +29,7 @@ import org.lwjgl.glfw.*;
 
 public class BaseMainActivity extends LoggableActivity {
     public static volatile ClipboardManager GLOBAL_CLIPBOARD;
+    public TouchCharInput touchCharInput;
 
     volatile public static boolean isInputStackCall;
 
@@ -121,8 +122,10 @@ public class BaseMainActivity extends LoggableActivity {
         setContentView(resId);
 
         try {
+
             // FIXME: is it safe fot multi thread?
             GLOBAL_CLIPBOARD = (ClipboardManager) getSystemService(CLIPBOARD_SERVICE);
+            touchCharInput = findViewById(R.id.editTextTextPersonName2);
 
             logFile = new File(Tools.DIR_GAME_HOME, "latestlog.txt");
             logFile.delete();
@@ -623,8 +626,29 @@ public class BaseMainActivity extends LoggableActivity {
 
     @Override
     public boolean dispatchKeyEvent(KeyEvent event) {
+        /*
+        Toast.makeText(this, event.toString(),Toast.LENGTH_LONG).show();
+        Toast.makeText(this, event.getUnicodeChar() + "",Toast.LENGTH_LONG).show();
+        Toast.makeText(this, event.getDevice().toString(), Toast.LENGTH_LONG).show();
+
+         */
+
+
         //Filtering useless events
-        if(event.getRepeatCount() != 0 || event.getAction() == KeyEvent.ACTION_MULTIPLE || event.getKeyCode() == KeyEvent.KEYCODE_UNKNOWN || (event.getFlags() & KeyEvent.FLAG_FALLBACK) == KeyEvent.FLAG_FALLBACK) return true;
+        if(event.getRepeatCount() != 0
+                || event.getAction() == KeyEvent.ACTION_MULTIPLE
+                || event.getKeyCode() == KeyEvent.KEYCODE_UNKNOWN
+                || (event.getFlags() & KeyEvent.FLAG_FALLBACK) == KeyEvent.FLAG_FALLBACK) return true;
+        Toast.makeText(this, "FIRST VERIF PASSED", Toast.LENGTH_LONG).show();
+
+        //Sometimes, key events comes from SOME keys of the software keyboard
+        //Even weirder, is is unknown why a key or another is selected to trigger a keyEvent
+        if((event.getFlags() & KeyEvent.FLAG_SOFT_KEYBOARD) == KeyEvent.FLAG_SOFT_KEYBOARD){
+            touchCharInput.dispatchKeyEvent(event);
+            return true;
+        }
+        Toast.makeText(this, "SECOND VERIF PASSED", Toast.LENGTH_LONG).show();
+
 
         //Sometimes, key events may come from the mouse
         if(event.getDevice() != null && (event.getDevice().getSources() & InputDevice.SOURCE_MOUSE_RELATIVE) == InputDevice.SOURCE_MOUSE_RELATIVE){

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/BaseMainActivity.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/BaseMainActivity.java
@@ -3,6 +3,7 @@ package net.kdt.pojavlaunch;
 import android.app.*;
 import android.content.*;
 import android.content.pm.PackageManager;
+import android.content.res.Configuration;
 import android.graphics.*;
 import android.os.*;
 import android.util.*;

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/BaseMainActivity.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/BaseMainActivity.java
@@ -879,22 +879,23 @@ public class BaseMainActivity extends LoggableActivity {
         // Catch back as Esc keycode at another place
         sendKeyPress(LWJGLGLFWKeycode.GLFW_KEY_ESCAPE);
     }
-    
-    public void hideKeyboard() {
-        try {
-            getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_HIDDEN);
-            if (getCurrentFocus() != null && getCurrentFocus().getWindowToken() != null) {
-                ((InputMethodManager) getSystemService(INPUT_METHOD_SERVICE)).hideSoftInputFromWindow((this).getCurrentFocus().getWindowToken(), 0);
-            }
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-    }
 
-    public void showKeyboard() {
-        ((InputMethodManager) getSystemService(INPUT_METHOD_SERVICE)).toggleSoftInput(InputMethodManager.SHOW_FORCED, InputMethodManager.HIDE_IMPLICIT_ONLY);
-        minecraftGLView.requestFocusFromTouch();
-        minecraftGLView.requestFocus();
+
+    /**
+     * Toggle on and off the soft keyboard, depending of the state
+     * The condition is prone to errors if the keyboard is being hidden without the consent
+     * of the current TouchCharInput
+     */
+    public void switchKeyboardState(){
+        if(touchCharInput.hasFocus()){
+            touchCharInput.clear();
+            touchCharInput.disable();
+
+        }else{
+            InputMethodManager imm = (InputMethodManager) getSystemService(INPUT_METHOD_SERVICE);
+            touchCharInput.enable();
+            touchCharInput.postDelayed(() -> imm.showSoftInput(touchCharInput, InputMethodManager.SHOW_IMPLICIT), 200);
+        }
     }
 
     protected void setRightOverride(boolean val) {

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/BaseMainActivity.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/BaseMainActivity.java
@@ -887,7 +887,9 @@ public class BaseMainActivity extends LoggableActivity {
      * of the current TouchCharInput
      */
     public void switchKeyboardState(){
-        if(touchCharInput.hasFocus()){
+        //If an hard keyboard is present, never trigger the soft one
+        if(touchCharInput.hasFocus()
+        || getResources().getConfiguration().keyboard == Configuration.KEYBOARD_QWERTY){
             touchCharInput.clear();
             touchCharInput.disable();
 

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MainActivity.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MainActivity.java
@@ -63,7 +63,7 @@ public class MainActivity extends BaseMainActivity {
                     for(int keycode : button.getProperties().keycodes){
                         switch (keycode) {
                             case ControlData.SPECIALBTN_KEYBOARD:
-                                showKeyboard();
+                                switchKeyboardState();
                                 break;
 
                             case ControlData.SPECIALBTN_TOGGLECTRL:

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MinecraftGLView.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MinecraftGLView.java
@@ -1,15 +1,8 @@
 package net.kdt.pojavlaunch;
 
 import android.content.*;
-import android.content.res.Configuration;
-import android.text.Editable;
-import android.text.SpannableStringBuilder;
 import android.util.*;
 import android.view.*;
-import android.view.inputmethod.BaseInputConnection;
-import android.view.inputmethod.EditorInfo;
-import android.view.inputmethod.InputConnection;
-import android.view.inputmethod.InputMethodManager;
 
 public class MinecraftGLView extends TextureView
 {
@@ -19,59 +12,7 @@ public class MinecraftGLView extends TextureView
 
     public MinecraftGLView(Context context, AttributeSet attributeSet) {
         super(context, attributeSet);
-        setOnFocusChangeListener(new OnFocusChangeListener() {
-            @Override
-            public void onFocusChange(View view, boolean b) {
-                if(!b) {
-                    ((InputMethodManager)view.getContext().getSystemService(Context.INPUT_METHOD_SERVICE)).hideSoftInputFromWindow(view.getWindowToken(),0);
-                }
-            }
-        });
     }
 
-    @Override
-    public InputConnection onCreateInputConnection(EditorInfo outAttrs) {
-        outAttrs.inputType = EditorInfo.TYPE_NULL;
-        Log.d("TypeableGLView","onCreateInputConnection");
-            return new MinecraftInputConnection(this, false);
-    }
-    @Override
-    public boolean onCheckIsTextEditor() {
-        return false;
-    }
-    public static boolean isHardKB(Context ctx) {
-        return ctx.getResources().getConfiguration().keyboard == Configuration.KEYBOARD_QWERTY;
-    }
     
-    
-}
-class MinecraftInputConnection extends BaseInputConnection {
-    private SpannableStringBuilder _editable;
-    BaseMainActivity parent;
-    public MinecraftInputConnection(View targetView, boolean fullEditor) {
-        super(targetView, fullEditor);
-
-        parent = (BaseMainActivity)targetView.getContext();
-    }
-
-    public Editable getEditable() {
-        if (_editable == null) {
-            _editable = (SpannableStringBuilder) Editable.Factory.getInstance()
-                    .newEditable("Placeholder");
-        }
-        return _editable;
-    }
-
-    public boolean commitText(CharSequence text, int newCursorPosition) {
-        for(int i = 0; i < text.length(); i++) parent.sendKeyPress(text.charAt(i));
-        return true;
-    }
-
-    @Override
-    public boolean deleteSurroundingText(int beforeLength, int afterLength) {
-        for(int i = 0; i < beforeLength; i++) {
-            parent.sendKeyPress(LWJGLGLFWKeycode.GLFW_KEY_BACKSPACE);
-        }
-        return true;
-    }
 }

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/ControlData.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/ControlData.java
@@ -68,8 +68,6 @@ public class ControlData implements Cloneable
     }
 
     public String name;
-    public float x;
-    public float y;
     private float width;         //Dp instead of Px now
     private float height;        //Dp instead of Px now
     public int[] keycodes;      //Should store up to 4 keys
@@ -181,17 +179,6 @@ public class ControlData implements Cloneable
                 for (ControlData data : getSpecialButtons())
                     if (keycode == data.keycodes[0])
                         specialButtonListener = data.specialButtonListener;
-
-
-        if (dynamicX == null) {
-            dynamicX = Float.toString(x);
-        }
-        if (dynamicY == null) {
-            dynamicY = Float.toString(y);
-        }
-        
-        x = insertDynamicPos(dynamicX);
-        y = insertDynamicPos(dynamicY);
     }
 
     private static float calculate(String math) {

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/ControlData.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/ControlData.java
@@ -5,6 +5,8 @@ import java.util.*;
 import net.kdt.pojavlaunch.*;
 import net.kdt.pojavlaunch.utils.*;
 import net.objecthunter.exp4j.*;
+import net.objecthunter.exp4j.function.Function;
+
 import org.lwjgl.glfw.*;
 
 import static net.kdt.pojavlaunch.LWJGLGLFWKeycode.GLFW_KEY_UNKNOWN;
@@ -182,7 +184,20 @@ public class ControlData implements Cloneable
     }
 
     private static float calculate(String math) {
-        return (float) new ExpressionBuilder(math).build().evaluate();
+        return (float) new ExpressionBuilder(math)
+                .function(new Function("dp", 1) {
+                    @Override
+                    public double apply(double... args) {
+                        return Tools.pxToDp((float) args[0]);
+                    }
+                })
+                .function(new Function("px", 1) {
+                    @Override
+                    public double apply(double... args) {
+                        return Tools.dpToPx((float) args[0]);
+                    }
+                })
+                .build().evaluate();
     }
 
     private static int[] inflateKeycodeArray(int[] keycodes){

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/ControlData.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/ControlData.java
@@ -3,6 +3,7 @@ package net.kdt.pojavlaunch.customcontrols;
 import android.util.*;
 import java.util.*;
 import net.kdt.pojavlaunch.*;
+import net.kdt.pojavlaunch.prefs.LauncherPreferences;
 import net.kdt.pojavlaunch.utils.*;
 import net.objecthunter.exp4j.*;
 import net.objecthunter.exp4j.function.Function;
@@ -167,7 +168,8 @@ public class ControlData implements Cloneable
         keyValueMap.put("screen_width", Integer.toString(CallbackBridge.physicalWidth));
         keyValueMap.put("screen_height", Integer.toString(CallbackBridge.physicalHeight));
         keyValueMap.put("margin", Integer.toString((int) Tools.dpToPx(2)));
-        
+        keyValueMap.put("preferred_scale", Float.toString(LauncherPreferences.PREF_BUTTONSIZE));
+
         // Insert value to ${variable}
         String insertedPos = JSONUtils.insertSingleJSONValue(dynamicPos, keyValueMap);
         

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/ControlLayout.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/ControlLayout.java
@@ -243,7 +243,7 @@ public class ControlLayout extends FrameLayout
 
 	}
 
-	private ArrayList<ControlButton> getButtonChildren(){
+	public ArrayList<ControlButton> getButtonChildren(){
 		ArrayList<ControlButton> children = new ArrayList<>();
 		for(int i=0; i<getChildCount(); ++i){
 			View v = getChildAt(i);

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/CustomControls.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/CustomControls.java
@@ -51,7 +51,7 @@ public class CustomControls {
 		this.mControlDataList.add(new ControlData(ctx, R.string.control_jump, new int[]{LWJGLGLFWKeycode.GLFW_KEY_SPACE}, "${right} - ${margin} * 2 - ${width}", "${bottom} - ${margin} * 2 - ${height}", true));
 
 		//The default controls are conform to the V2
-		version = 2;
+		version = 3;
 	}
     
     public ControlData findControlData(int keycode) {
@@ -67,7 +67,7 @@ public class CustomControls {
 	
 	public void save(String path) throws IOException {
 		//Current version is the V2 so the version as to be marked as 2 !
-		version = 2;
+		version = 3;
 
 		Tools.write(path, Tools.GLOBAL_GSON.toJson(this));
 	}

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/LayoutConverter.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/LayoutConverter.java
@@ -41,15 +41,13 @@ public class LayoutConverter {
                     LWJGLGLFWKeycode.GLFW_KEY_UNKNOWN,
                     LWJGLGLFWKeycode.GLFW_KEY_UNKNOWN,
                     LWJGLGLFWKeycode.GLFW_KEY_UNKNOWN};
+            n_button.isDynamicBtn = button.getBoolean("isDynamicBtn");
             n_button.dynamicX = button.getString("dynamicX");
             n_button.dynamicY = button.getString("dynamicY");
-            n_button.isDynamicBtn = button.getBoolean("isDynamicBtn");
             n_button.name = button.getString("name");
             n_button.opacity = ((float)((button.getInt("transparency")-100)*-1))/100f;
             n_button.passThruEnabled = button.getBoolean("passThruEnabled");
             n_button.isToggle = button.getBoolean("isToggle");
-            n_button.x = button.getInt("x");
-            n_button.y = button.getInt("y");
             n_button.setHeight(button.getInt("height"));
             n_button.setWidth(button.getInt("width"));
             if(convertLookType) {

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/TouchCharInput.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/TouchCharInput.java
@@ -2,6 +2,7 @@ package net.kdt.pojavlaunch.customcontrols;
 
 import android.content.Context;
 import android.util.AttributeSet;
+import android.view.KeyEvent;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -30,6 +31,12 @@ public class TouchCharInput extends androidx.appcompat.widget.AppCompatEditText 
 
 
     private boolean isDoingInternalChanges = false;
+
+    /**
+     * We take the new chars, and send them to the game.
+     * If less chars are present, remove some.
+     * The text is always cleaned up.
+     */
     @Override
     protected void onTextChanged(CharSequence text, int start, int lengthBefore, int lengthAfter) {
         super.onTextChanged(text, start, lengthBefore, lengthAfter);
@@ -50,6 +57,33 @@ public class TouchCharInput extends androidx.appcompat.widget.AppCompatEditText 
         clear();
     }
 
+
+    /**
+     * When we change from app to app, the keyboard gets disabled.
+     * So, we disable the object
+     */
+    @Override
+    public void onWindowFocusChanged(boolean hasWindowFocus) {
+        super.onWindowFocusChanged(hasWindowFocus);
+        disable();
+    }
+
+    /**
+     * Intercepts the back key to disable focus
+     * Does not affect the rest of the activity.
+     */
+    @Override
+    public boolean onKeyPreIme(final int keyCode, final KeyEvent event) {
+        if (event.getKeyCode() == KeyEvent.KEYCODE_BACK && event.getAction() == KeyEvent.ACTION_UP) {
+            disable();
+        }
+        return super.onKeyPreIme(keyCode, event);
+    }
+
+    @Override
+    public void setSelection(int index) {
+        super.setSelection(5);
+    }
 
     /**
      * Clear the EditText from any leftover inputs
@@ -84,6 +118,7 @@ public class TouchCharInput extends androidx.appcompat.widget.AppCompatEditText 
      * Lose ability to exist, take focus and have some text being input
      */
     public void disable(){
+        clear();
         setVisibility(GONE);
         clearFocus();
         setEnabled(false);

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/TouchCharInput.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/TouchCharInput.java
@@ -132,6 +132,8 @@ public class TouchCharInput extends androidx.appcompat.widget.AppCompatEditText 
     private void setup(){
         setOnEditorActionListener((textView, i, keyEvent) -> {
             sendEnter();
+            clear();
+            disable();
             return false;
         });
         clear();

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/TouchCharInput.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/TouchCharInput.java
@@ -1,11 +1,7 @@
 package net.kdt.pojavlaunch.customcontrols;
 
 import android.content.Context;
-import android.text.Editable;
-import android.text.TextWatcher;
 import android.util.AttributeSet;
-import android.view.KeyEvent;
-import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -32,34 +28,27 @@ public class TouchCharInput extends androidx.appcompat.widget.AppCompatEditText 
         setup();
     }
 
+
     private boolean isDoingInternalChanges = false;
-
-    TextWatcher mTextWatcher = new TextWatcher() {
-        //TODO Engineer a more performant system
-        @Override
-        public void beforeTextChanged(CharSequence charSequence, int i, int i1, int i2) {
-            if(isDoingInternalChanges) return;
-
-            for(int j=0; j<charSequence.length(); ++j){
+    @Override
+    protected void onTextChanged(CharSequence text, int start, int lengthBefore, int lengthAfter) {
+        super.onTextChanged(text, start, lengthBefore, lengthAfter);
+        if(isDoingInternalChanges){
+            isDoingInternalChanges = false;
+            return;
+        }
+        if(lengthAfter < lengthBefore){
+            for(int i=0; i< lengthBefore-lengthAfter; ++i){
                 CallbackBridge.sendKeycode(LWJGLGLFWKeycode.GLFW_KEY_BACKSPACE, '\u0008', 0, 0, true);
             }
-        }
-
-        @Override
-        public void onTextChanged(CharSequence charSequence, int start, int lengthBefore, int lengthAfter) {
-            if(isDoingInternalChanges) return;
-
-            for (int i=0; i<charSequence.length(); ++i){
-                CallbackBridge.sendChar(charSequence.charAt(i));
+        }else{
+            for(int i=lengthBefore, index=lengthBefore+start; i < lengthAfter; ++i){
+                CallbackBridge.sendChar(text.charAt(index));
             }
-
         }
 
-        @Override
-        public void afterTextChanged(Editable editable) {
-            isDoingInternalChanges = false;
-        }
-    };
+        clear();
+    }
 
 
     /**
@@ -68,14 +57,14 @@ public class TouchCharInput extends androidx.appcompat.widget.AppCompatEditText 
      */
     public void clear(){
         isDoingInternalChanges = true;
-        setText("");
+        setText("          ");
+        setSelection(5);
     }
 
     /**
-     * Send the text stored to the game
+     * Send the enter key.
      */
-    private void send(){
-        //TODO proper focus removal ?
+    private void sendEnter(){
         BaseMainActivity.sendKeyPress(LWJGLGLFWKeycode.GLFW_KEY_ENTER);
         clear();
     }
@@ -95,10 +84,8 @@ public class TouchCharInput extends androidx.appcompat.widget.AppCompatEditText 
      * Lose ability to exist, take focus and have some text being input
      */
     public void disable(){
-
         setVisibility(GONE);
         clearFocus();
-        //setFocusable(false);
         setEnabled(false);
     }
 
@@ -108,17 +95,11 @@ public class TouchCharInput extends androidx.appcompat.widget.AppCompatEditText 
      * This function deals with anything that has to be executed when the constructor is called
      */
     private void setup(){
-        //The text watcher used to look and send text
-        addTextChangedListener(mTextWatcher);
-
         setOnEditorActionListener((textView, i, keyEvent) -> {
-            //TODO remove the focus from the EditText ?
-            send();
+            sendEnter();
             return false;
         });
-        isDoingInternalChanges = true;
-        setText("");
-
+        clear();
         disable();
     }
 

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/TouchCharInput.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/TouchCharInput.java
@@ -1,0 +1,106 @@
+package net.kdt.pojavlaunch.customcontrols;
+
+import android.content.Context;
+import android.os.Bundle;
+import android.text.Editable;
+import android.text.TextWatcher;
+import android.util.AttributeSet;
+import android.view.KeyEvent;
+import android.view.inputmethod.EditorInfo;
+import android.view.inputmethod.InputConnection;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.core.view.inputmethod.EditorInfoCompat;
+import androidx.core.view.inputmethod.InputConnectionCompat;
+import androidx.core.view.inputmethod.InputContentInfoCompat;
+
+import net.kdt.pojavlaunch.BaseMainActivity;
+import net.kdt.pojavlaunch.LWJGLGLFWKeycode;
+
+import org.lwjgl.glfw.CallbackBridge;
+
+/**
+ * This class is intended for sending characters used in chat via the virtual keyboard
+ */
+public class TouchCharInput extends androidx.appcompat.widget.AppCompatEditText {
+    public TouchCharInput(@NonNull Context context) {
+        super(context);
+        setup();
+    }
+    public TouchCharInput(@NonNull Context context, @Nullable AttributeSet attrs) {
+        super(context, attrs);
+        setup();
+    }
+    public TouchCharInput(@NonNull Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+        setup();
+    }
+
+    private boolean isClearingText = false;
+
+    TextWatcher mTextWatcher = new TextWatcher() {
+        //TODO Engineer a more performant system
+        @Override
+        public void beforeTextChanged(CharSequence charSequence, int i, int i1, int i2) {
+            if(isClearingText) return;
+
+            for(int j=0; j<charSequence.length(); ++j){
+                CallbackBridge.sendKeycode(LWJGLGLFWKeycode.GLFW_KEY_BACKSPACE, '\u0008', 0, 0, true);
+            }
+        }
+
+        @Override
+        public void onTextChanged(CharSequence charSequence, int start, int lengthBefore, int lengthAfter) {
+            if(isClearingText) return;
+
+            for (int i=0; i<charSequence.length(); ++i){
+                CallbackBridge.sendChar(charSequence.charAt(i));
+            }
+
+        }
+
+        @Override
+        public void afterTextChanged(Editable editable) {
+            if(isClearingText){
+                isClearingText = false;
+                editable.clear();
+            }
+        }
+    };
+
+
+    /**
+     * Clear the EditText from any leftover inputs
+     * It does not affect the in-game input
+     */
+    public void clear(){
+        isClearingText = true;
+        setText(" ");
+    }
+
+    /**
+     * Send the text stored to the game
+     */
+    private void send(){
+        //TODO proper focus removal ?
+        BaseMainActivity.sendKeyPress(LWJGLGLFWKeycode.GLFW_KEY_ENTER);
+        clear();
+    }
+
+    /**
+     * This function deals with anything that has to be executed when the constructor is called
+     */
+    private void setup(){
+        //The text watcher used to look and send text
+        addTextChangedListener(mTextWatcher);
+
+        setOnEditorActionListener((textView, i, keyEvent) -> {
+            //TODO remove the focus from the EditText ?
+            send();
+            return false;
+        });
+    }
+
+}

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/TouchCharInput.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/TouchCharInput.java
@@ -1,20 +1,14 @@
 package net.kdt.pojavlaunch.customcontrols;
 
 import android.content.Context;
-import android.os.Bundle;
 import android.text.Editable;
 import android.text.TextWatcher;
 import android.util.AttributeSet;
 import android.view.KeyEvent;
-import android.view.inputmethod.EditorInfo;
-import android.view.inputmethod.InputConnection;
-import android.widget.TextView;
+import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.core.view.inputmethod.EditorInfoCompat;
-import androidx.core.view.inputmethod.InputConnectionCompat;
-import androidx.core.view.inputmethod.InputContentInfoCompat;
 
 import net.kdt.pojavlaunch.BaseMainActivity;
 import net.kdt.pojavlaunch.LWJGLGLFWKeycode;
@@ -38,13 +32,13 @@ public class TouchCharInput extends androidx.appcompat.widget.AppCompatEditText 
         setup();
     }
 
-    private boolean isClearingText = false;
+    private boolean isDoingInternalChanges = false;
 
     TextWatcher mTextWatcher = new TextWatcher() {
         //TODO Engineer a more performant system
         @Override
         public void beforeTextChanged(CharSequence charSequence, int i, int i1, int i2) {
-            if(isClearingText) return;
+            if(isDoingInternalChanges) return;
 
             for(int j=0; j<charSequence.length(); ++j){
                 CallbackBridge.sendKeycode(LWJGLGLFWKeycode.GLFW_KEY_BACKSPACE, '\u0008', 0, 0, true);
@@ -53,7 +47,7 @@ public class TouchCharInput extends androidx.appcompat.widget.AppCompatEditText 
 
         @Override
         public void onTextChanged(CharSequence charSequence, int start, int lengthBefore, int lengthAfter) {
-            if(isClearingText) return;
+            if(isDoingInternalChanges) return;
 
             for (int i=0; i<charSequence.length(); ++i){
                 CallbackBridge.sendChar(charSequence.charAt(i));
@@ -63,10 +57,7 @@ public class TouchCharInput extends androidx.appcompat.widget.AppCompatEditText 
 
         @Override
         public void afterTextChanged(Editable editable) {
-            if(isClearingText){
-                isClearingText = false;
-                editable.clear();
-            }
+            isDoingInternalChanges = false;
         }
     };
 
@@ -76,8 +67,8 @@ public class TouchCharInput extends androidx.appcompat.widget.AppCompatEditText 
      * It does not affect the in-game input
      */
     public void clear(){
-        isClearingText = true;
-        setText(" ");
+        isDoingInternalChanges = true;
+        setText("");
     }
 
     /**
@@ -88,6 +79,30 @@ public class TouchCharInput extends androidx.appcompat.widget.AppCompatEditText 
         BaseMainActivity.sendKeyPress(LWJGLGLFWKeycode.GLFW_KEY_ENTER);
         clear();
     }
+
+    /**
+     * Regain ability to exist, take focus and have some text being input
+     */
+    public void enable(){
+        setEnabled(true);
+        setFocusable(true);
+        setVisibility(VISIBLE);
+        requestFocus();
+
+    }
+
+    /**
+     * Lose ability to exist, take focus and have some text being input
+     */
+    public void disable(){
+
+        setVisibility(GONE);
+        clearFocus();
+        //setFocusable(false);
+        setEnabled(false);
+    }
+
+
 
     /**
      * This function deals with anything that has to be executed when the constructor is called
@@ -101,6 +116,10 @@ public class TouchCharInput extends androidx.appcompat.widget.AppCompatEditText 
             send();
             return false;
         });
+        isDoingInternalChanges = true;
+        setText("");
+
+        disable();
     }
 
 }

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/buttons/ControlButton.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/buttons/ControlButton.java
@@ -315,27 +315,7 @@ public class ControlButton extends androidx.appcompat.widget.AppCompatButton imp
                     setY(currentY);
 
                     ControlButton nearButton;
-                    /*
-                    for(ControlButton button : ((ControlLayout) getParent()).getButtonChildren()){
-                        if(button == ControlButton.this){
-                            continue;
-                        }
-                        if(distanceBetweenViews(ControlButton.this, button) < MIN_DISTANCE){
-                            if(Math.abs(getTop() - button.getBottom()) < MIN_DISTANCE){ // Bottom snap
-                                currentY = button.getBottom();
-                            }
-                            //System.out.println(button.getTop() - getBottom());
-                            if(Math.abs(button.getTop() - getBottom()) < MIN_DISTANCE){ //Top snap
-                                currentY = button.getTop() - getHeight();
-                            }
-                            if(Math.abs(button.getLeft() - getRight()) < MIN_DISTANCE){ //Left snap
-                                currentX = button.getLeft() - getWidth();
-                            }
-                            if(Math.abs(getLeft() - button.getRight()) < MIN_DISTANCE){ //Right snap
-                                currentX = button.getRight();
-                            }
-                        }
-                     */
+
                     for(ControlButton button :  ((ControlLayout) getParent()).getButtonChildren()){
                         if(button == this) continue;
                         if(MathUtils.dist(button.getX() + button.getProperties().getWidth()/2,
@@ -353,47 +333,32 @@ public class ControlButton extends androidx.appcompat.widget.AppCompatButton imp
                         float left = getX();
                         float right = getX() + getProperties().getWidth();
 
-
-
                         /*
-                        if(MathUtils.dist(button.getX(), button.getY(), currentX, currentY) < MIN_DISTANCE){
-                            currentX = button.getX();
-                            currentY = button.getY();
-                        }
-                        */
-
+                         * For each axis, we try to snap to the nearest
+                         */
                         if(Math.abs(top - button_bottom) < MIN_DISTANCE){ // Bottom snap
                             currentY = button_bottom;
-                        }
-                        //System.out.println(button.getTop() - getBottom());
-                        if(Math.abs(button_top - bottom) < MIN_DISTANCE){ //Top snap
+                        }else if(Math.abs(button_top - bottom) < MIN_DISTANCE){ //Top snap
                             currentY = button_top - getProperties().getHeight();
                         }
                         if(currentY != getY()){ //If we snapped
-                            if(Math.abs(button_left - left) < MIN_DISTANCE){ //Left align snap
+                            if(Math.abs(button_left - left) < MIN_DISTANCE/2){ //Left align snap
                                 currentX = button_left;
-
-                            }
-                            if(Math.abs(button_right - right) < MIN_DISTANCE){ //Right align snap
+                            }else if(Math.abs(button_right - right) < MIN_DISTANCE/2){ //Right align snap
                                 currentX = button_right - getProperties().getWidth();
-
                             }
                         }
 
                         if(Math.abs(button_left - right) < MIN_DISTANCE){ //Left snap
                             currentX = button_left - getProperties().getWidth();
-                        }
-                        if(Math.abs(left - button_right) < MIN_DISTANCE){ //Right snap
+                        }else if(Math.abs(left - button_right) < MIN_DISTANCE){ //Right snap
                             currentX = button_right;
                         }
                         if(currentX != getX()){
-                            if(Math.abs(button_top - top) < MIN_DISTANCE){
+                            if(Math.abs(button_top - top) < MIN_DISTANCE/2){
                                 currentY = button_top;
-
-                            }
-                            if(Math.abs(button_bottom - bottom) < MIN_DISTANCE){
+                            }else if(Math.abs(button_bottom - bottom) < MIN_DISTANCE/2){
                                 currentY = button_bottom - getProperties().getHeight();
-
                             }
                         }
 

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/buttons/ControlButton.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/buttons/ControlButton.java
@@ -326,6 +326,25 @@ public class ControlButton extends androidx.appcompat.widget.AppCompatButton imp
     }
 
     /**
+     * Passe a series of checks to determine if the ControlButton is available to be snapped on.
+     *
+     * @param button
+     * @return whether or not the button
+     */
+    protected boolean canSnap(ControlButton button){
+        float MIN_DISTANCE = Tools.dpToPx(8);
+
+        if(button == this) return false;
+        if(com.google.android.material.math.MathUtils.dist(
+                button.getX() + button.getWidth()/2f,
+                button.getY() + button.getHeight()/2f,
+                getX() + getWidth()/2f,
+                getY() + getHeight()/2f) > Math.max(button.getWidth()/2f + getWidth()/2f, button.getHeight()/2f + getHeight()/2f) + MIN_DISTANCE) return false;
+
+        return true;
+    }
+
+    /**
      * Try to snap, then align to neighboring buttons, given the provided coordinates.
      * The new position is automatically applied to the View,
      * regardless of if the View snapped or not.
@@ -335,19 +354,14 @@ public class ControlButton extends androidx.appcompat.widget.AppCompatButton imp
      */
     protected void snapAndAlign(float x, float y){
         //Time to snap !
-        float MIN_DISTANCE = Tools.dpToPx(10);
+        float MIN_DISTANCE = Tools.dpToPx(8);
 
         setX(x);
         setY(y);
 
         for(ControlButton button :  ((ControlLayout) getParent()).getButtonChildren()){
             //Step 1: Filter unwanted buttons
-            if(button == this) continue;
-            if(com.google.android.material.math.MathUtils.dist(
-                    button.getX() + button.getWidth()/2f,
-                    button.getY() + button.getHeight()/2f,
-                    getX() + getWidth()/2f,
-                    getY() + getHeight()/2f) > Math.max(button.getWidth()/2f + getWidth()/2f, button.getHeight()/2f + getHeight()/2f) + MIN_DISTANCE) continue;
+            if(!canSnap(button)) continue;
 
             //Step 2: Get Coordinates
             float button_top = button.getY();

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/buttons/ControlButton.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/buttons/ControlButton.java
@@ -402,9 +402,9 @@ public class ControlButton extends androidx.appcompat.widget.AppCompatButton imp
 
             //Step 3: For each axis, we try to snap to the nearest
             if(Math.abs(top - button_bottom) < MIN_DISTANCE){ // Bottom snap
-                dynamicY = applySize(button.getProperties().dynamicY, button) + applySize(" + ${height}", button) ;
+                dynamicY = applySize(button.getProperties().dynamicY, button) + applySize(" + ${height}", button) + " + ${margin}" ;
             }else if(Math.abs(button_top - bottom) < MIN_DISTANCE){ //Top snap
-                dynamicY = applySize(button.getProperties().dynamicY, button) + " - ${height}";
+                dynamicY = applySize(button.getProperties().dynamicY, button) + " - ${height} - ${margin}";
             }
             if(!dynamicY.equals(generateDynamicY(getY()))){ //If we snapped
                 if(Math.abs(button_left - left) < MIN_DISTANCE){ //Left align snap
@@ -415,9 +415,9 @@ public class ControlButton extends androidx.appcompat.widget.AppCompatButton imp
             }
 
             if(Math.abs(button_left - right) < MIN_DISTANCE){ //Left snap
-                dynamicX = applySize(button.getProperties().dynamicX, button) + " - ${width}";
+                dynamicX = applySize(button.getProperties().dynamicX, button) + " - ${width} - ${margin}";
             }else if(Math.abs(left - button_right) < MIN_DISTANCE){ //Right snap
-                dynamicX = applySize(button.getProperties().dynamicX, button) + applySize(" + ${width}", button);
+                dynamicX = applySize(button.getProperties().dynamicX, button) + applySize(" + ${width}", button) + " + ${margin}";
             }
             if(!dynamicX.equals(generateDynamicX(getX()))){ //If we snapped
                 if(Math.abs(button_top - top) < MIN_DISTANCE){ //Top align snap
@@ -434,10 +434,13 @@ public class ControlButton extends androidx.appcompat.widget.AppCompatButton imp
     }
 
     /**
+     * Do a pre-conversion of an equation using values from a button,
+     * so the variables can be used for another button
      *
-     * @param equation
-     * @param button
-     * @return
+     * Internal use only.
+     * @param equation The dynamic position as a String
+     * @param button The button to get the values from.
+     * @return The pre-processed equation as a String.
      */
     private static String applySize(String equation, ControlButton button){
         return equation

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/buttons/ControlButton.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/buttons/ControlButton.java
@@ -8,7 +8,9 @@ import android.view.*;
 import android.view.View.*;
 import android.widget.*;
 
-import com.google.android.material.math.MathUtils;
+
+
+import androidx.core.math.MathUtils;
 
 import net.kdt.pojavlaunch.customcontrols.ControlData;
 import net.kdt.pojavlaunch.customcontrols.ControlLayout;
@@ -312,7 +314,10 @@ public class ControlButton extends androidx.appcompat.widget.AppCompatButton imp
                 mCanTriggerLongClick = false;
 
                 if (!mProperties.isDynamicBtn) {
-                    snapAndAlign(event.getRawX() - downX, event.getRawY() - downY);
+                    snapAndAlign(
+                        MathUtils.clamp(event.getRawX() - downX, 0, CallbackBridge.physicalWidth - getWidth()),
+                        MathUtils.clamp(event.getRawY() - downY, 0, CallbackBridge.physicalHeight - getHeight())
+                    );
                 }
                 break;
         }
@@ -338,7 +343,8 @@ public class ControlButton extends androidx.appcompat.widget.AppCompatButton imp
         for(ControlButton button :  ((ControlLayout) getParent()).getButtonChildren()){
             //Step 1: Filter unwanted buttons
             if(button == this) continue;
-            if(MathUtils.dist(button.getX() + button.getWidth()/2f,
+            if(com.google.android.material.math.MathUtils.dist(
+                    button.getX() + button.getWidth()/2f,
                     button.getY() + button.getHeight()/2f,
                     getX() + getWidth()/2f,
                     getY() + getHeight()/2f) > Math.max(button.getWidth()/2f + getWidth()/2f, button.getHeight()/2f + getHeight()/2f) + MIN_DISTANCE) continue;
@@ -373,7 +379,7 @@ public class ControlButton extends androidx.appcompat.widget.AppCompatButton imp
             }else if(Math.abs(left - button_right) < MIN_DISTANCE){ //Right snap
                 x = button_right;
             }
-            if(x != getX()){
+            if(x != getX()){ //If we snapped
                 if(Math.abs(button_top - top) < MIN_DISTANCE){ //Top align snap
                     y = button_top;
                 }else if(Math.abs(button_bottom - bottom) < MIN_DISTANCE){ //Bottom align snap

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/buttons/ControlButton.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/buttons/ControlButton.java
@@ -440,8 +440,11 @@ public class ControlButton extends androidx.appcompat.widget.AppCompatButton imp
      * @return
      */
     private static String applySize(String equation, ControlButton button){
-        return equation.replace("${height}", " px(" + Tools.pxToDp(button.getProperties().getHeight()) + ") /" + PREF_BUTTONSIZE + " * ${preferred_scale}")
-                .replace("${width}", " px(" + Tools.pxToDp(button.getProperties().getWidth()) + ") / " + PREF_BUTTONSIZE + " * ${preferred_scale}");
+        return equation
+                .replace("${right}", "(${screen_width} - ${width})")
+                .replace("${bottom}","(${screen_height} - ${height})")
+                .replace("${height}", "(px(" + Tools.pxToDp(button.getProperties().getHeight()) + ") /" + PREF_BUTTONSIZE + " * ${preferred_scale})")
+                .replace("${width}", "(px(" + Tools.pxToDp(button.getProperties().getWidth()) + ") / " + PREF_BUTTONSIZE + " * ${preferred_scale})");
     }
 
     public int computeStrokeWidth(float widthInPercent){

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/buttons/ControlButton.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/buttons/ControlButton.java
@@ -379,7 +379,6 @@ public class ControlButton extends androidx.appcompat.widget.AppCompatButton imp
      */
     protected void snapAndAlign(float x, float y){
         float MIN_DISTANCE = Tools.dpToPx(8);
-        boolean success = false;
         String dynamicX = generateDynamicX(x);
         String dynamicY = generateDynamicY(y);
 
@@ -415,7 +414,6 @@ public class ControlButton extends androidx.appcompat.widget.AppCompatButton imp
                 dynamicY = applySize(button.getProperties().dynamicY, button) + " - ${height}";
             }
             if(y != getY()){ //If we snapped
-                success = true;
                 if(Math.abs(button_left - left) < MIN_DISTANCE){ //Left align snap
                     //x = button_left;
                     dynamicX = applySize(button.getProperties().dynamicX, button);
@@ -455,8 +453,8 @@ public class ControlButton extends androidx.appcompat.widget.AppCompatButton imp
      * @return
      */
     private static String applySize(String equation, ControlButton button){
-        return equation.replace("${height}", " px(" + Tools.pxToDp(button.getProperties().getHeight()) / PREF_BUTTONSIZE + ") * ${preferred_scale}")
-                .replace("${width}", " px(" + button.getProperties().getWidth() / PREF_BUTTONSIZE + ") * ${preferred_scale}");
+        return equation.replace("${height}", " px(" + Tools.pxToDp(button.getProperties().getHeight()) + ") /" + PREF_BUTTONSIZE + " * ${preferred_scale}")
+                .replace("${width}", " px(" + Tools.pxToDp(button.getProperties().getWidth()) + ") / " + PREF_BUTTONSIZE + " * ${preferred_scale}");
     }
 
     public int computeStrokeWidth(float widthInPercent){

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/buttons/ControlButton.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/buttons/ControlButton.java
@@ -74,12 +74,6 @@ public class ControlButton extends androidx.appcompat.widget.AppCompatButton imp
         //Visibility
         properties.isHideable = !properties.containsKeycode(ControlData.SPECIALBTN_TOGGLECTRL) && !properties.containsKeycode(ControlData.SPECIALBTN_VIRTUALMOUSE);
 
-        //Position
-        if (!properties.isDynamicBtn) {
-            properties.dynamicX = properties.x / CallbackBridge.physicalWidth + " * ${screen_width}";
-            properties.dynamicY = properties.y / CallbackBridge.physicalHeight + " * ${screen_height}";
-        }
-
         properties.update();
         return properties;
     }
@@ -94,18 +88,15 @@ public class ControlButton extends androidx.appcompat.widget.AppCompatButton imp
         setText(properties.name);
 
         if (changePos) {
-            setX(properties.x);
-            setY(properties.y);
+            setX(properties.insertDynamicPos(mProperties.dynamicX));
+            setY(properties.insertDynamicPos(mProperties.dynamicY));
         }
 
         if (properties.specialButtonListener == null) {
             // A non-special button or inside custom controls screen so skip listener
         } else if (properties.specialButtonListener instanceof View.OnClickListener) {
             setOnClickListener((View.OnClickListener) properties.specialButtonListener);
-            // setOnLongClickListener(null);
-            // setOnTouchListener(null);
         } else if (properties.specialButtonListener instanceof View.OnTouchListener) {
-            // setOnLongClickListener(null);
             setOnTouchListener((View.OnTouchListener) properties.specialButtonListener);
         } else {
             throw new IllegalArgumentException("Field " + ControlData.class.getName() + ".specialButtonListener must be View.OnClickListener or View.OnTouchListener, but was " +
@@ -145,8 +136,8 @@ public class ControlButton extends androidx.appcompat.widget.AppCompatButton imp
         
         // Re-calculate position
         mProperties.update();
-        setX(mProperties.x);
-        setY(mProperties.y);
+        setX(mProperties.insertDynamicPos(mProperties.dynamicX));
+        setY(mProperties.insertDynamicPos(mProperties.dynamicY));
         
         setModified(true);
     }
@@ -161,8 +152,14 @@ public class ControlButton extends androidx.appcompat.widget.AppCompatButton imp
         super.setX(x);
 
         if (!mProperties.isDynamicBtn) {
-            mProperties.x = x;
-            mProperties.dynamicX = x / CallbackBridge.physicalWidth + " * ${screen_width}";
+
+            if(x + (mProperties.getWidth()/2f) > CallbackBridge.physicalWidth/2f){
+                System.out.println(mProperties.getWidth());
+                mProperties.dynamicX = (x + mProperties.getWidth()) / CallbackBridge.physicalWidth + " * ${screen_width} - ${width}";
+            }else{
+                mProperties.dynamicX = x / CallbackBridge.physicalWidth + " * ${screen_width}";
+            }
+
             setModified(true);
         }
     }
@@ -172,8 +169,14 @@ public class ControlButton extends androidx.appcompat.widget.AppCompatButton imp
         super.setY(y);
 
         if (!mProperties.isDynamicBtn) {
-            mProperties.y = y;
-            mProperties.dynamicY = y / CallbackBridge.physicalHeight + " * ${screen_height}";
+
+            if(y + (mProperties.getHeight()/2f) > CallbackBridge.physicalHeight/2f){
+                System.out.println(mProperties.getHeight());
+                mProperties.dynamicY = (y + mProperties.getHeight()) / CallbackBridge.physicalHeight + " * ${screen_height} - ${height}";
+            }else{
+                mProperties.dynamicY = y / CallbackBridge.physicalHeight + " * ${screen_height}";
+            }
+
             setModified(true);
         }
     }

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/buttons/ControlButton.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/buttons/ControlButton.java
@@ -369,11 +369,32 @@ public class ControlButton extends androidx.appcompat.widget.AppCompatButton imp
                         if(Math.abs(button_top - bottom) < MIN_DISTANCE){ //Top snap
                             currentY = button_top - getProperties().getHeight();
                         }
+                        if(currentY != getY()){ //If we snapped
+                            if(Math.abs(button_left - left) < MIN_DISTANCE){ //Left align snap
+                                currentX = button_left;
+
+                            }
+                            if(Math.abs(button_right - right) < MIN_DISTANCE){ //Right align snap
+                                currentX = button_right - getProperties().getWidth();
+
+                            }
+                        }
+
                         if(Math.abs(button_left - right) < MIN_DISTANCE){ //Left snap
                             currentX = button_left - getProperties().getWidth();
                         }
                         if(Math.abs(left - button_right) < MIN_DISTANCE){ //Right snap
                             currentX = button_right;
+                        }
+                        if(currentX != getX()){
+                            if(Math.abs(button_top - top) < MIN_DISTANCE){
+                                currentY = button_top;
+
+                            }
+                            if(Math.abs(button_bottom - bottom) < MIN_DISTANCE){
+                                currentY = button_bottom - getProperties().getHeight();
+
+                            }
                         }
 
                     }

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/buttons/ControlButton.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/buttons/ControlButton.java
@@ -138,8 +138,14 @@ public class ControlButton extends androidx.appcompat.widget.AppCompatButton imp
         
         // Re-calculate position
         mProperties.update();
-        setX(mProperties.insertDynamicPos(mProperties.dynamicX));
-        setY(mProperties.insertDynamicPos(mProperties.dynamicY));
+        if(!mProperties.isDynamicBtn){
+            setX(getX());
+            setY(getY());
+        }else {
+            setX(mProperties.insertDynamicPos(mProperties.dynamicX));
+            setY(mProperties.insertDynamicPos(mProperties.dynamicY));
+        }
+
         
         setModified(true);
     }

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/buttons/ControlButton.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/buttons/ControlButton.java
@@ -400,42 +400,29 @@ public class ControlButton extends androidx.appcompat.widget.AppCompatButton imp
             float left = getX();
             float right = getX() + getWidth();
 
-            //For context aware snapping
-            boolean atTopArea = button.getY() + getHeight()/2 < CallbackBridge.physicalHeight/2;
-            boolean atLeftArea = button.getX() + getWidth()/2 < CallbackBridge.physicalWidth/2;
-
             //Step 3: For each axis, we try to snap to the nearest
             if(Math.abs(top - button_bottom) < MIN_DISTANCE){ // Bottom snap
-                //y = button_bottom;
                 dynamicY = applySize(button.getProperties().dynamicY, button) + applySize(" + ${height}", button) ;
-
             }else if(Math.abs(button_top - bottom) < MIN_DISTANCE){ //Top snap
-                //y = button_top - getHeight();
                 dynamicY = applySize(button.getProperties().dynamicY, button) + " - ${height}";
             }
-            if(y != getY()){ //If we snapped
+            if(!dynamicY.equals(generateDynamicY(getY()))){ //If we snapped
                 if(Math.abs(button_left - left) < MIN_DISTANCE){ //Left align snap
-                    //x = button_left;
                     dynamicX = applySize(button.getProperties().dynamicX, button);
                 }else if(Math.abs(button_right - right) < MIN_DISTANCE){ //Right align snap
-                    //x = button_right - getWidth();
                     dynamicX = applySize(button.getProperties().dynamicX, button) + applySize(" + ${width}", button) + " - ${width}";
                 }
             }
 
             if(Math.abs(button_left - right) < MIN_DISTANCE){ //Left snap
-                //x = button_left - getWidth();
                 dynamicX = applySize(button.getProperties().dynamicX, button) + " - ${width}";
             }else if(Math.abs(left - button_right) < MIN_DISTANCE){ //Right snap
-                //x = button_right;
                 dynamicX = applySize(button.getProperties().dynamicX, button) + applySize(" + ${width}", button);
             }
-            if(x != getX()){ //If we snapped
+            if(!dynamicX.equals(generateDynamicX(getX()))){ //If we snapped
                 if(Math.abs(button_top - top) < MIN_DISTANCE){ //Top align snap
-                    //y = button_top;
                     dynamicY = applySize(button.getProperties().dynamicY, button);
                 }else if(Math.abs(button_bottom - bottom) < MIN_DISTANCE){ //Bottom align snap
-                    //y = button_bottom - getHeight();
                     dynamicY = applySize(button.getProperties().dynamicY, button) + applySize(" + ${height}", button) + " - ${height}";
                 }
             }

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/buttons/ControlButton.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/buttons/ControlButton.java
@@ -8,6 +8,8 @@ import android.view.*;
 import android.view.View.*;
 import android.widget.*;
 
+import androidx.core.math.MathUtils;
+
 import net.kdt.pojavlaunch.customcontrols.ControlData;
 import net.kdt.pojavlaunch.customcontrols.ControlLayout;
 import net.kdt.pojavlaunch.customcontrols.handleview.*;
@@ -304,8 +306,8 @@ public class ControlButton extends androidx.appcompat.widget.AppCompatButton imp
                 mCanTriggerLongClick = false;
 
                 if (!mProperties.isDynamicBtn) {
-                    setX(event.getRawX() - downX);
-                    setY(event.getRawY() - downY);
+                    setX(MathUtils.clamp(event.getRawX() - downX,0, CallbackBridge.physicalWidth));
+                    setY(MathUtils.clamp(event.getRawY() - downY, 0, CallbackBridge.physicalHeight));
                 }
                 break;
         }

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/buttons/ControlButton.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/buttons/ControlButton.java
@@ -351,14 +351,14 @@ public class ControlButton extends androidx.appcompat.widget.AppCompatButton imp
 
             //Step 2: Get Coordinates
             float button_top = button.getY();
-            float button_bottom = button_top + button.getBottom();
+            float button_bottom = button_top + button.getHeight();
             float button_left = button.getX();
-            float button_right = button_left + button.getRight();
+            float button_right = button_left + button.getWidth();
 
             float top = getY();
-            float bottom = getY() + getBottom();
+            float bottom = getY() + getHeight();
             float left = getX();
-            float right = getX() + getRight();
+            float right = getX() + getWidth();
 
             //Step 3: For each axis, we try to snap to the nearest
             if(Math.abs(top - button_bottom) < MIN_DISTANCE){ // Bottom snap

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/buttons/ControlDrawer.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/buttons/ControlDrawer.java
@@ -101,6 +101,19 @@ public class ControlDrawer extends ControlButton {
         resizeButtons();
     }
 
+    /**
+     * Check whether or not the button passed as a parameter belongs to this drawer.
+     *
+     * @param button The button to look for
+     * @return Whether the button is in the buttons list of the drawer.
+     */
+    public boolean containsChild(ControlButton button){
+        for(ControlButton childButton : buttons){
+            if (childButton == button) return true;
+        }
+        return false;
+    }
+
     @Override
     public ControlData preProcessProperties(ControlData properties, ControlLayout layout) {
         ControlData data = super.preProcessProperties(properties, layout);
@@ -127,6 +140,11 @@ public class ControlDrawer extends ControlButton {
         }
 
         return super.onTouchEvent(event);
+    }
+
+    @Override
+    protected boolean canSnap(ControlButton button) {
+        return super.canSnap(button) && !containsChild(button);
     }
 
     @Override

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/buttons/ControlDrawer.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/buttons/ControlDrawer.java
@@ -62,23 +62,23 @@ public class ControlDrawer extends ControlButton {
         for(int i=0; i < buttons.size(); ++i){
             switch (drawerData.orientation){
                 case RIGHT:
-                    buttons.get(i).setX(getX() + (drawerData.properties.getWidth() + Tools.dpToPx(2))*(i+1) );
-                    buttons.get(i).setY(getY());
+                    buttons.get(i).setDynamicX(generateDynamicX(getX() + (drawerData.properties.getWidth() + Tools.dpToPx(2))*(i+1) ));
+                    buttons.get(i).setDynamicY(generateDynamicY(getY()));
                     break;
 
                 case LEFT:
-                    buttons.get(i).setX(getX() - (drawerData.properties.getWidth() + Tools.dpToPx(2))*(i+1) );
-                    buttons.get(i).setY(getY());
+                    buttons.get(i).setDynamicX(generateDynamicX(getX() - (drawerData.properties.getWidth() + Tools.dpToPx(2))*(i+1)));
+                    buttons.get(i).setDynamicY(generateDynamicY(getY()));
                     break;
 
                 case UP:
-                    buttons.get(i).setY(getY() - (drawerData.properties.getHeight() + Tools.dpToPx(2))*(i+1) );
-                    buttons.get(i).setX(getX());
+                    buttons.get(i).setDynamicY(generateDynamicY(getY() - (drawerData.properties.getHeight() + Tools.dpToPx(2))*(i+1)));
+                    buttons.get(i).setDynamicX(generateDynamicX(getX()));
                     break;
 
                 case DOWN:
-                    buttons.get(i).setY(getY() + (drawerData.properties.getHeight() + Tools.dpToPx(2))*(i+1) );
-                    buttons.get(i).setX(getX());
+                    buttons.get(i).setDynamicY(generateDynamicY(getY() + (drawerData.properties.getHeight() + Tools.dpToPx(2))*(i+1)));
+                    buttons.get(i).setDynamicX(generateDynamicX(getX()));
                     break;
             }
             buttons.get(i).updateProperties();

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/buttons/ControlDrawer.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/buttons/ControlDrawer.java
@@ -62,23 +62,23 @@ public class ControlDrawer extends ControlButton {
         for(int i=0; i < buttons.size(); ++i){
             switch (drawerData.orientation){
                 case RIGHT:
-                    buttons.get(i).setX(drawerData.properties.x + (drawerData.properties.getWidth() + Tools.dpToPx(2))*(i+1) );
-                    buttons.get(i).setY(drawerData.properties.y);
+                    buttons.get(i).setX(getX() + (drawerData.properties.getWidth() + Tools.dpToPx(2))*(i+1) );
+                    buttons.get(i).setY(getY());
                     break;
 
                 case LEFT:
-                    buttons.get(i).setX(drawerData.properties.x - (drawerData.properties.getWidth() + Tools.dpToPx(2))*(i+1) );
-                    buttons.get(i).setY(drawerData.properties.y);
+                    buttons.get(i).setX(getX() - (drawerData.properties.getWidth() + Tools.dpToPx(2))*(i+1) );
+                    buttons.get(i).setY(getY());
                     break;
 
                 case UP:
-                    buttons.get(i).setY(drawerData.properties.y - (drawerData.properties.getHeight() + Tools.dpToPx(2))*(i+1) );
-                    buttons.get(i).setX(drawerData.properties.x);
+                    buttons.get(i).setY(getY() - (drawerData.properties.getHeight() + Tools.dpToPx(2))*(i+1) );
+                    buttons.get(i).setX(getX());
                     break;
 
                 case DOWN:
-                    buttons.get(i).setY(drawerData.properties.y + (drawerData.properties.getHeight() + Tools.dpToPx(2))*(i+1) );
-                    buttons.get(i).setX(drawerData.properties.x);
+                    buttons.get(i).setY(getY() + (drawerData.properties.getHeight() + Tools.dpToPx(2))*(i+1) );
+                    buttons.get(i).setX(getX());
                     break;
             }
             buttons.get(i).updateProperties();

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/handleview/EditControlButtonPopup.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/handleview/EditControlButtonPopup.java
@@ -218,9 +218,8 @@ public class EditControlButtonPopup {
 
         editDynamicX.setEnabled(properties.isDynamicBtn);
         editDynamicY.setEnabled(properties.isDynamicBtn);
-        editDynamicX.setHint(Float.toString(properties.x));
         editDynamicX.setText(properties.dynamicX);
-        editDynamicY.setHint(Float.toString(properties.y));
+
         editDynamicY.setText(properties.dynamicY);
 
         seekBarOpacity.setProgress((int) (properties.opacity*100));
@@ -297,8 +296,8 @@ public class EditControlButtonPopup {
         properties.setHeight(Float.parseFloat(editHeight.getText().toString()));
 
         properties.isDynamicBtn = checkDynamicPosition.isChecked();
-        properties.dynamicX = editDynamicX.getText().toString().isEmpty() ? properties.dynamicX = Float.toString(properties.x) : editDynamicX.getText().toString();
-        properties.dynamicY = editDynamicY.getText().toString().isEmpty() ? properties.dynamicY = Float.toString(properties.y) : editDynamicY.getText().toString();
+        if(!editDynamicX.getText().toString().isEmpty()) properties.dynamicX = editDynamicX.getText().toString();
+        if(!editDynamicY.getText().toString().isEmpty()) properties.dynamicY = editDynamicY.getText().toString();
 
         button.updateProperties();
     }

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/handleview/EditControlButtonPopup.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/handleview/EditControlButtonPopup.java
@@ -8,6 +8,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.ArrayAdapter;
 import android.widget.CheckBox;
+import android.widget.CompoundButton;
 import android.widget.EditText;
 import android.widget.ImageButton;
 import android.widget.SeekBar;
@@ -177,6 +178,8 @@ public class EditControlButtonPopup {
 
         hideUselessViews();
 
+        defineDynamicCheckChange();
+
         setupCheckerboards();
     }
 
@@ -192,6 +195,22 @@ public class EditControlButtonPopup {
 
     protected void hideUselessViews(){
         (v.findViewById(R.id.editOrientation_textView)).setVisibility(View.GONE);
+
+        (v.findViewById(R.id.editDynamicPositionX_textView)).setVisibility(View.GONE);
+        (v.findViewById(R.id.editDynamicPositionY_textView)).setVisibility(View.GONE);
+        editDynamicX.setVisibility(View.GONE);
+        editDynamicY.setVisibility(View.GONE);
+    }
+
+    protected void defineDynamicCheckChange(){
+        checkDynamicPosition.setOnCheckedChangeListener((compoundButton, b) -> {
+            int visibility = b ? View.VISIBLE : View.GONE;
+
+            (v.findViewById(R.id.editDynamicPositionX_textView)).setVisibility(visibility);
+            (v.findViewById(R.id.editDynamicPositionY_textView)).setVisibility(visibility);
+            editDynamicX.setVisibility(visibility);
+            editDynamicY.setVisibility(visibility);
+        });
     }
 
     private void setupCheckerboards(){

--- a/app_pojavlauncher/src/main/java/org/lwjgl/glfw/CallbackBridge.java
+++ b/app_pojavlauncher/src/main/java/org/lwjgl/glfw/CallbackBridge.java
@@ -80,6 +80,15 @@ public class CallbackBridge {
         // sendData(JRE_TYPE_KEYCODE_CONTROL, keycode, Character.toString(keychar), Boolean.toString(isDown), modifiers);
     }
 
+    /**
+     * Send only the char to the input bridge
+     * Intended for chat functions, or anything that only requires writing text
+     * @param keychar the char to send
+     */
+    public static void sendChar(char keychar){
+        nativeSendChar(keychar);
+    }
+
     public static void sendMouseKeycode(int button, int modifiers, boolean isDown) {
         DEBUG_STRING.append("MouseKey=").append(button).append(", down=").append(isDown).append("\n");
         // if (isGrabbing()) DEBUG_STRING.append("MouseGrabStrace: " + android.util.Log.getStackTraceString(new Throwable()) + "\n");

--- a/app_pojavlauncher/src/main/res/layout/main_with_customctrl.xml
+++ b/app_pojavlauncher/src/main/res/layout/main_with_customctrl.xml
@@ -46,6 +46,18 @@
 				android:layout_height="wrap_content"
 				app:srcCompat="@drawable/pointer" />
 
+			<net.kdt.pojavlaunch.customcontrols.TouchCharInput
+				android:imeOptions="flagNoFullscreen|flagNoPersonalizedLearning|actionSend"
+				android:inputType="text|textNoSuggestions|textImeMultiLine"
+				android:background="@android:color/darker_gray"
+				android:id="@+id/editTextTextPersonName2"
+				android:layout_width="wrap_content"
+				android:layout_height="wrap_content"
+				android:ems="10"
+				android:layout_marginTop="20px"
+
+				android:text="" />
+
 		</net.kdt.pojavlaunch.customcontrols.ControlLayout>
 
 		<LinearLayout

--- a/app_pojavlauncher/src/main/res/layout/main_with_customctrl.xml
+++ b/app_pojavlauncher/src/main/res/layout/main_with_customctrl.xml
@@ -51,12 +51,9 @@
 				android:inputType="text|textNoSuggestions|textImeMultiLine"
 				android:background="@android:color/darker_gray"
 				android:id="@+id/editTextTextPersonName2"
-				android:layout_width="wrap_content"
-				android:layout_height="wrap_content"
-				android:ems="10"
-				android:layout_marginTop="20px"
-
-				android:text="" />
+				android:layout_width="1dp"
+				android:layout_height="1dp"
+				android:ems="10" />
 
 		</net.kdt.pojavlaunch.customcontrols.ControlLayout>
 

--- a/app_pojavlauncher/src/main/res/values/strings.xml
+++ b/app_pojavlauncher/src/main/res/values/strings.xml
@@ -178,7 +178,7 @@
     <string name="customctrl_stroke_width">Stroke width</string>
     <string name="customctrl_stroke_color">Stroke color</string>
     
-    <string name="customctrl_dynamicpos">Dynamic position</string>
+    <string name="customctrl_dynamicpos">Manual Dynamic position</string>
     <string name="customctrl_dynamicpos_x">Dynamic X</string>
     <string name="customctrl_dynamicpos_y">Dynamic Y</string>
 


### PR DESCRIPTION

<details>
<summary>
<b>[V2.1] Changelog</b>
</summary>

# Intro
When the control v2 arrived, not everything could be fitted into the same PR, since time was a constraint and that many of the features were mature enough to go into mainline.

This said, smaller updates are more or less scheduled to come at random time intervals.
*(unless I'm paid, then I can dedicate time to bring a feature a client wants)*

## Full cross-device compatibility
*It was one of the missing features from the controls v2.*
The position of any ControlButton has been forcefully migrated to its dynamic equivalent.

- All screen aspect ratios are now supported, thanks to all dynamic positions being computed from the nearest borders of the screen instead of the top left.²
- Buttons now scale towards the center by default, instead of the bottom right.²
-  Buttons can now not be moved outside of the screen, avoiding accidental loss of buttons on the outside.

² Only concerns buttons with the automatic equations, not the user input ones.

## Context-aware snapping and alignment
Building a layout is frustratingly tedious, partially due to the inability to place buttons where we want.
This issue is now gone with auto snapping and alignment of buttons one to another.
This feature is also  *slightly* **context-aware**, which means a button can replace himself relatively to the button he snapped/aligned on !



## Miscellaneous :
- The new layout is in **NO SHAPE OR FORM** compatible with any previous versions of the controls, this is partially intended to force to move over the new scheme and take advantage of the new features when controls are shared.

- The dynamic position stuff is now hidden to the user by default. It can be toggled as easily as before for those who know how the system works. 

## What's left to do ?
- A message or something to tell the user his current layout isn't valid ?
- ~~Rename the "dynamic position" toggle to something a bit more fitting since all equations are dynamic under the hood.~~
- Surely something else.

## Images
2.1 controls at 100% scale:
![2.1 controls at 100% scale](https://cdn.discordapp.com/attachments/867462167245619280/871504989355384842/Screenshot_20210801-142926_PojavLauncher_Minecraft_Java_Edition_for_Android.jpg)

The same controls at 200% scale, you can see that buttons are still properly aligned.![2.1 controls at 200% scale](https://cdn.discordapp.com/attachments/867462167245619280/871505800928063498/Screenshot_20210801-143241_PojavLauncher_Minecraft_Java_Edition_for_Android.jpg)

[The controls in video](https://cdn.discordapp.com/attachments/867462167245619280/872170838500179998/20210803_193301.mp4)

</details>


<details>
<summary>
<b>[V2.2] Changelog</b>
</summary>

# Controls v2.2 update ~~aka I can fucking type stuff now~~
## Introduction
Since when I started working to improve the launcher from a user experience perspective, something didn't feel right.
*Actually, almost nothing felt right*
I hopped onto my favourite minecraft version and TADA !
**I could NOT type anything...**
Note: This update is smaller than expected due to the sheer amount of hate @artdev has towards anything remotely user friendly, so "one *byte* at a time I guess", sorry @LegacyGamerHD


## Full software keyboard compatibility
It changes everything.
The current codebase relies on an OUT OF SPECIFICATION system: Receiving keyEvents from software keyboards, whereas keyevents are theoretically dedicated to hardware events.

As such, some keyboards were unable to type anything, while others had missing characters in the supported set.


## Toggle keyboard button
When the KEYBOARD special action was introduced, it was intended to be a toggle on and off for the keyboard.
But multiple issues focus wise stopped it from being implemented.

This update brings back a fully working toggle system, capable of detecting changes in the keyboard focus state by intercepting common events that make the keyboard lose focus.


## Miscellaneous 
- The system is fully compatible with the existing 2.1 update, as it does not introduce any change in the specification. It is merely an extension of the current system.
- This update does not eliminate all the issues related to receiving keyEvents. Arrow soft keys are still passed as hardware ones.
- The toggle won't do anything when a hardware keyboard is plugged in.

## Images
Tested with the following keyboards: at least 6 weren't working on my device before the update.
![Compatibility list](https://cdn.discordapp.com/attachments/867462167245619280/874039965313544232/Screenshot_20210804-234306.png)

Example of the textbox (now invisible, untouchable) allowing keys to work.
![Exemple of Asian looking chars](https://cdn.discordapp.com/attachments/867462167245619280/874040071693680681/Screenshot_20210802-171217.png)

# Conclusion
I can finally uninstall 
hacker's keyboard,
Gboard,
the Puyin input IME
and the yandex keyboard.

</details>