### PR TITLE
tweaks

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -65,16 +65,13 @@ body {
 <body>
 
 <div class="navbar">
-  <a href="https://pojavlauncherteam.github.io/updates/local.html">Recent Update</a>
   <a href="https://pojavlauncherteam.github.io/">Website</a>
-  <a href="https://www.minecraft.net/en-us/store/minecraft-java-edition/buy">Account Generator</a>
-  <a href="https://www.patreon.com/pojavlauncher"><b>Donate</b></a>
+  <a href="https://rscdmtalt.github.io/pojavpatreon/"><b>Donate</b></a>
 </div>
 
 <div class="changelog">
   <h6>Oh No! This is not the way that this should display! Report anything about this <a href="#">here.</a></h6>
   <h2>PojavLauncher</h2>
-	<h2>If you want to support PojavLauncher and get some nice perks in the process, consider <b><a href="https://www.patreon.com/pojavlauncher">subscribing to our Patreon</a></b></h2>
 	  <b>• Original: Zhuowei Zhang, Boardwalk app.</b><br>
 	  <b>• Developers:</b><br>
     <a href="https://github.com/khanhduytran0">Tran Khanh Duy</a>, <a href="https://github.com/artdeell">artdeell</a>, <a href="https://github.com/LegacyGamerHD">LegacyGamerHD</a>.<br>
@@ -84,7 +81,7 @@ body {
 
 	  <b>• Best helper for help testing: </b>
 	  <a href="https://github.com/pedrosouzabrasil">Pedro Souza</a>.<br>
-	  <b>• NEW: <a href="https://pojavlauncherteam.github.io/updates/117.html"> Preliminary support for Minecraft 1.17</a></b><br>
+	  <b>• <a href="https://pojavlauncherteam.github.io/updates/117.html"> Preliminary support for Minecraft 1.17</a></b><br>
 	  <b>• <a href="https://github.com/PojavLauncherTeam/PojavLauncher/issues">Bug report</a></b><br>
 	  <b>• <a href="https://github.com/PojavLauncherTeam/PojavLauncher/actions">Download latest development build.</a></b><br>
 	  <b>• <a href="https://discord.gg/6RpEJda">Join PojavLauncher Discord server.</a></b><br>


### PR DESCRIPTION
What's up. rscDoesMoreTrolling here, and welcome to another pr full of changelog tweaks
(don't ask why my name is rscDMTalt)

Here's what i've done this time

1. renaming "account generator" to "my account" gets me boring, so i remived it instead
2. removed the "Recent Update" tab, since the 1.17 support was months ago.
3. removed the "NEW:" beside "Preliminary 1.17 support because it was months ago
4. having the donation text in the changelog seems crappy to me, so i made a page about it (+ used some unused file in a pojav github release)

Do note that these are not final yet.


I'm planning to add a bottom "navbar" in some time since "pojav needs to do a litle trolling (-Sunsky, UID:647469014146351122)