### PR TITLE
Changes to the renderer strings (names), check description

### DIFF
--- a/app_pojavlauncher/src/main/res/values/strings.xml
+++ b/app_pojavlauncher/src/main/res/values/strings.xml
@@ -100,11 +100,11 @@
     <string name="mcl_setting_category_general">General settings</string>
     <string name="mcl_setting_category_scaling">Scaling settings</string>
     <string name="mcl_setting_category_renderer">Renderer</string>
-    <string name="mcl_setting_renderer_gles2_4">holy gl4es: supports 1.0–1.19+</string>
-    <string name="mcl_setting_renderer_virgl">virglrenderer (OpenGL ES 3): exports OpenGL 4.3</string>
-    <string name="mcl_setting_renderer_vgpu">vgpu (OpenGL ES 3): exports OpenGL 3.0</string>
-    <string name="mcl_setting_renderer_vulkan_zink">zink (Vulkan): exports OpenGL 4.6</string>
-    <string name="mcl_setting_renderer_angle">tinywrapper ANGLE Vulkan</string>
+    <string name="mcl_setting_renderer_gles2_4">Holy GL4ES - (all versions, fastest)</string>
+    <string name="mcl_setting_renderer_virgl">virglrenderer - (release 1.7+, slowest)</string>
+    <string name="mcl_setting_renderer_vgpu">vgpu - (up to 1.16.5, faster)</string>
+    <string name="mcl_setting_renderer_vulkan_zink">zink (old_beta b1.8+, slowest)</string>
+    <string name="mcl_setting_renderer_angle">ANGLE - (release 1.17+, slower)</string>
     <string name="mcl_setting_category_veroption">Version type will be in version list</string>
     <string name="mcl_setting_veroption_release">Release</string>
     <string name="mcl_setting_veroption_snapshot">Snapshot</string>

--- a/app_pojavlauncher/src/main/res/values/strings.xml
+++ b/app_pojavlauncher/src/main/res/values/strings.xml
@@ -100,11 +100,11 @@
     <string name="mcl_setting_category_general">General settings</string>
     <string name="mcl_setting_category_scaling">Scaling settings</string>
     <string name="mcl_setting_category_renderer">Renderer</string>
-    <string name="mcl_setting_renderer_gles2_4">Holy GL4ES - (all versions, fastest)</string>
-    <string name="mcl_setting_renderer_virgl">virglrenderer - (release 1.7+, slowest)</string>
-    <string name="mcl_setting_renderer_vgpu">vgpu - (up to 1.16.5, faster)</string>
-    <string name="mcl_setting_renderer_vulkan_zink">zink - (old_beta b1.8+, slowest)</string>
-    <string name="mcl_setting_renderer_angle">ANGLE - (release 1.17+, slower)</string>
+    <string name="mcl_setting_renderer_gles2_4">Holy GL4ES - (all versions, fast)</string>
+    <string name="mcl_setting_renderer_virgl">virglrenderer - (release 1.7+, slow)</string>
+    <string name="mcl_setting_renderer_vgpu">vgpu - (up to 1.16.5, fast)</string>
+    <string name="mcl_setting_renderer_vulkan_zink">zink - (old_beta b1.8+, slow)</string>
+    <string name="mcl_setting_renderer_angle">ANGLE - (release 1.17+, medium)</string>
     <string name="mcl_setting_category_veroption">Version type will be in version list</string>
     <string name="mcl_setting_veroption_release">Release</string>
     <string name="mcl_setting_veroption_snapshot">Snapshot</string>

--- a/app_pojavlauncher/src/main/res/values/strings.xml
+++ b/app_pojavlauncher/src/main/res/values/strings.xml
@@ -103,7 +103,7 @@
     <string name="mcl_setting_renderer_gles2_4">Holy GL4ES - (all versions, fastest)</string>
     <string name="mcl_setting_renderer_virgl">virglrenderer - (release 1.7+, slowest)</string>
     <string name="mcl_setting_renderer_vgpu">vgpu - (up to 1.16.5, faster)</string>
-    <string name="mcl_setting_renderer_vulkan_zink">zink (old_beta b1.8+, slowest)</string>
+    <string name="mcl_setting_renderer_vulkan_zink">zink - (old_beta b1.8+, slowest)</string>
     <string name="mcl_setting_renderer_angle">ANGLE - (release 1.17+, slower)</string>
     <string name="mcl_setting_category_veroption">Version type will be in version list</string>
     <string name="mcl_setting_veroption_release">Release</string>

--- a/app_pojavlauncher/src/main/res/values/strings.xml
+++ b/app_pojavlauncher/src/main/res/values/strings.xml
@@ -104,7 +104,7 @@
     <string name="mcl_setting_renderer_virgl">virglrenderer - (release 1.7+, slow)</string>
     <string name="mcl_setting_renderer_vgpu">vgpu - (up to 1.16.5, fast)</string>
     <string name="mcl_setting_renderer_vulkan_zink">zink - (old_beta b1.8+, slow)</string>
-    <string name="mcl_setting_renderer_angle">ANGLE - (release 1.17+, medium)</string>
+    <string name="mcl_setting_renderer_angle">ANGLE - (release 1.17+, mid)</string>
     <string name="mcl_setting_category_veroption">Version type will be in version list</string>
     <string name="mcl_setting_veroption_release">Release</string>
     <string name="mcl_setting_veroption_snapshot">Snapshot</string>


### PR DESCRIPTION
**Changes sorted by performance:**

holy gl4es: supports 1.0–1.19+ >>> **Holy GL4ES - (all versions, fastest)**
vgpu (OpenGL ES 3): exports OpenGL 3.0 >>> **vgpu - (up to 1.16.5, faster)**
tinywrapper ANGLE Vulkan >>> **ANGLE - (release 1.17+, slower)**
virglrenderer (OpenGL ES 3): exports OpenGL 4.3 >>> **virglrenderer - (release 1.7+, slowest)**
zink (Vulkan): exports OpenGL 4.6 >>> **zink (old_beta b1.8+, slowest)**