### PR TITLE
Revert "enforce non focusable when disabled"

### DIFF
--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/keyboard/TouchCharInput.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/keyboard/TouchCharInput.java
@@ -135,7 +135,7 @@ public class TouchCharInput extends androidx.appcompat.widget.AppCompatEditText 
         setVisibility(GONE);
         clearFocus();
         setEnabled(false);
-        setFocusable(false);
+        //setFocusable(false);
     }
 
     /** Send the enter key. */


### PR DESCRIPTION
This bugged me by making the keyboard stop opening
My device: Motorola One Vision - Android 12 (CrDroid 8.8)
this revert commit ef9d5e347c58a241ac50943965c659860161c6e5