### PR TITLE
Feat[Gyro]: Use sensor fusion implementation

### DIFF
--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/GyroControl.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/GyroControl.java
@@ -59,12 +59,10 @@ public class GyroControl implements SensorEventListener, GrabListener{
             mPreviousTimestamp = sensorEvent.timestamp;
             return;
         }
-
         SensorManager.getAngleChange(mAngleDifference, mCurrentRotation, mPreviousRotation);
-        double factor = (sensorEvent.timestamp - mPreviousTimestamp) * 0.000001;
 
-        CallbackBridge.mouseX -= mAngleDifference[mSwapXY ? 2 : 1] * 100 * LauncherPreferences.PREF_GYRO_SENSITIVITY * xFactor * factor;
-        CallbackBridge.mouseY += mAngleDifference[mSwapXY ? 1 : 2] * 100 * LauncherPreferences.PREF_GYRO_SENSITIVITY * yFactor * factor;
+        CallbackBridge.mouseX -= (mAngleDifference[mSwapXY ? 2 : 1] * 1000 * LauncherPreferences.PREF_GYRO_SENSITIVITY * xFactor);
+        CallbackBridge.mouseY += (mAngleDifference[mSwapXY ? 1 : 2] * 1000  * LauncherPreferences.PREF_GYRO_SENSITIVITY * yFactor);
         CallbackBridge.sendCursorPos(CallbackBridge.mouseX, CallbackBridge.mouseY);
 
         mPreviousTimestamp = sensorEvent.timestamp;

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/GyroControl.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/GyroControl.java
@@ -91,11 +91,11 @@ public class GyroControl implements SensorEventListener, GrabListener{
         public void onOrientationChanged(int i) {
             int surfaceRotation = mWindowManager.getDefaultDisplay().getRotation();
             if(surfaceRotation == mSurfaceRotation) return;
-            mSurfaceRotation = surfaceRotation;
 
             if(i == OrientationEventListener.ORIENTATION_UNKNOWN) {
                 return; //change nothing
             }
+            mSurfaceRotation = surfaceRotation;
 
             if((315 < i && i <= 360) || (i < 45) ) {
                 mSwapXY = true;

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/GyroControl.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/GyroControl.java
@@ -5,6 +5,7 @@ import android.hardware.Sensor;
 import android.hardware.SensorEvent;
 import android.hardware.SensorEventListener;
 import android.hardware.SensorManager;
+import android.util.Log;
 import android.view.OrientationEventListener;
 
 import net.kdt.pojavlaunch.prefs.LauncherPreferences;
@@ -87,6 +88,9 @@ public class GyroControl implements SensorEventListener, GrabListener{
 
         @Override
         public void onOrientationChanged(int i) {
+            if(i == OrientationEventListener.ORIENTATION_UNKNOWN) {
+                return; //change nothing
+            }
             if((315 < i && i <= 360) || (i < 45) ) {
                 mSwapXY = true;
                 xFactor = 1;

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/GyroControl.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/GyroControl.java
@@ -1,17 +1,21 @@
 package net.kdt.pojavlaunch;
 
+import android.app.Activity;
 import android.content.Context;
 import android.hardware.Sensor;
 import android.hardware.SensorEvent;
 import android.hardware.SensorEventListener;
 import android.hardware.SensorManager;
 import android.view.OrientationEventListener;
+import android.view.WindowManager;
 
 import net.kdt.pojavlaunch.prefs.LauncherPreferences;
 
 import org.lwjgl.glfw.CallbackBridge;
 
 public class GyroControl implements SensorEventListener, GrabListener{
+    private final WindowManager mWindowManager;
+    private int mSurfaceRotation;
     private final SensorManager mSensorManager;
     private final Sensor mSensor;
     private final OrientationCorrectionListener mCorrectionListener;
@@ -25,10 +29,12 @@ public class GyroControl implements SensorEventListener, GrabListener{
     private final float[] mCurrentRotation = new float[16];
     private final float[] mAngleDifference = new float[3];
 
-    public GyroControl(Context context) {
-        mSensorManager = (SensorManager) context.getSystemService(Context.SENSOR_SERVICE);
+    public GyroControl(Activity activity) {
+        mWindowManager = activity.getWindowManager();
+        mSurfaceRotation = -10;
+        mSensorManager = (SensorManager) activity.getSystemService(Context.SENSOR_SERVICE);
         mSensor = mSensorManager.getDefaultSensor(Sensor.TYPE_GAME_ROTATION_VECTOR);
-        mCorrectionListener = new OrientationCorrectionListener(context);
+        mCorrectionListener = new OrientationCorrectionListener(activity);
     }
 
     public void enable() {
@@ -83,9 +89,14 @@ public class GyroControl implements SensorEventListener, GrabListener{
 
         @Override
         public void onOrientationChanged(int i) {
+            int surfaceRotation = mWindowManager.getDefaultDisplay().getRotation();
+            if(surfaceRotation == mSurfaceRotation) return;
+            mSurfaceRotation = surfaceRotation;
+
             if(i == OrientationEventListener.ORIENTATION_UNKNOWN) {
                 return; //change nothing
             }
+
             if((315 < i && i <= 360) || (i < 45) ) {
                 mSwapXY = true;
                 xFactor = 1;

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/GyroControl.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/GyroControl.java
@@ -5,7 +5,6 @@ import android.hardware.Sensor;
 import android.hardware.SensorEvent;
 import android.hardware.SensorEventListener;
 import android.hardware.SensorManager;
-import android.util.Log;
 import android.view.OrientationEventListener;
 
 import net.kdt.pojavlaunch.prefs.LauncherPreferences;
@@ -18,7 +17,6 @@ public class GyroControl implements SensorEventListener, GrabListener{
     private final OrientationCorrectionListener mCorrectionListener;
     private boolean mShouldHandleEvents;
     private boolean mFirstPass;
-    private long mPreviousTimestamp;
     private float xFactor; // -1 or 1 depending on device orientation
     private float yFactor;
     private boolean mSwapXY;
@@ -57,7 +55,6 @@ public class GyroControl implements SensorEventListener, GrabListener{
 
         if(mFirstPass){  // Setup initial position
             mFirstPass = false;
-            mPreviousTimestamp = sensorEvent.timestamp;
             return;
         }
         SensorManager.getAngleChange(mAngleDifference, mCurrentRotation, mPreviousRotation);
@@ -65,8 +62,6 @@ public class GyroControl implements SensorEventListener, GrabListener{
         CallbackBridge.mouseX -= (mAngleDifference[mSwapXY ? 2 : 1] * 1000 * LauncherPreferences.PREF_GYRO_SENSITIVITY * xFactor);
         CallbackBridge.mouseY += (mAngleDifference[mSwapXY ? 1 : 2] * 1000  * LauncherPreferences.PREF_GYRO_SENSITIVITY * yFactor);
         CallbackBridge.sendCursorPos(CallbackBridge.mouseX, CallbackBridge.mouseY);
-
-        mPreviousTimestamp = sensorEvent.timestamp;
     }
 
     @Override

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/GyroControl.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/GyroControl.java
@@ -89,6 +89,9 @@ public class GyroControl implements SensorEventListener, GrabListener{
 
         @Override
         public void onOrientationChanged(int i) {
+            // Force to wait to be in game before setting factors
+            // Theoretically, one could use the whole interface in portrait...
+            if(!mShouldHandleEvents) return;
             int surfaceRotation = mWindowManager.getDefaultDisplay().getRotation();
             if(surfaceRotation == mSurfaceRotation) return;
 

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/LauncherPreferences.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/LauncherPreferences.java
@@ -54,7 +54,7 @@ public class LauncherPreferences {
     public static boolean PREF_JAVA_SANDBOX = true;
     public static int PREF_SCALE_FACTOR = 100;
     public static boolean PREF_ENALBE_GYRO = false;
-    public static float PREF_GYRO_SENSITIVITY = 100;
+    public static float PREF_GYRO_SENSITIVITY = 1f;
     public static int PREF_GYRO_SAMPLE_RATE = 16;
 
     public static boolean PREF_GYRO_INVERT_X = false;


### PR DESCRIPTION
# Why
The current gyroscope only implementation does not work well on many devices, where sensor fusion is usually needed to get a clean output.
Issues included:
- (anti-)clockwise oriented input
- gimbal locking


### Notes
- The initial sensitivity may not be the same, as no frame of reference was established 