### PR TITLE
[V 2.Gyro] Controls: Reduce gyroscope jitter

### DIFF
--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/GyroControl.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/GyroControl.java
@@ -20,7 +20,7 @@ import java.util.Arrays;
 
 public class GyroControl implements SensorEventListener, GrabListener {
     /* How much distance has to be moved before taking into account the gyro */
-    private static final float REALLY_LOW_PASS_THRESHOLD = 1.4F;
+    private static final float REALLY_LOW_PASS_THRESHOLD = 1.3F;
 
     private final WindowManager mWindowManager;
     private int mSurfaceRotation;

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/GyroControl.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/GyroControl.java
@@ -70,7 +70,7 @@ public class GyroControl implements SensorEventListener, GrabListener {
         // Copy the old array content
         System.arraycopy(mCurrentRotation, 0, mPreviousRotation, 0, 16);
         SensorManager.getRotationMatrixFromVector(mCurrentRotation, sensorEvent.values);
-        System.out.println(Arrays.toString(sensorEvent.values));
+        
 
         if(mFirstPass){  // Setup initial position
             mFirstPass = false;

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/LauncherPreferences.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/LauncherPreferences.java
@@ -49,6 +49,7 @@ public class LauncherPreferences {
     public static boolean PREF_ENABLE_GYRO = false;
     public static float PREF_GYRO_SENSITIVITY = 1f;
     public static int PREF_GYRO_SAMPLE_RATE = 16;
+    public static int PREF_GYRO_DAMPER_WINDOW = 100;
 
     public static boolean PREF_GYRO_INVERT_X = false;
 
@@ -91,6 +92,7 @@ public class LauncherPreferences {
         PREF_ENABLE_GYRO = DEFAULT_PREF.getBoolean("enableGyro", false);
         PREF_GYRO_SENSITIVITY = ((float)DEFAULT_PREF.getInt("gyroSensitivity", 100))/100f;
         PREF_GYRO_SAMPLE_RATE = DEFAULT_PREF.getInt("gyroSampleRate", 16);
+        PREF_GYRO_DAMPER_WINDOW = DEFAULT_PREF.getInt("gyroDamperWindow", 100);
         PREF_GYRO_INVERT_X = DEFAULT_PREF.getBoolean("gyroInvertX", false);
         PREF_GYRO_INVERT_Y = DEFAULT_PREF.getBoolean("gyroInvertY", false);
         PREF_FORCE_VSYNC = DEFAULT_PREF.getBoolean("force_vsync", false);

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/screens/LauncherPreferenceControlFragment.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/screens/LauncherPreferenceControlFragment.java
@@ -23,6 +23,7 @@ public class LauncherPreferenceControlFragment extends LauncherPreferenceFragmen
         int gyroSampleRate = LauncherPreferences.PREF_GYRO_SAMPLE_RATE;
         float mouseSpeed = LauncherPreferences.PREF_MOUSESPEED;
         float gyroSpeed = LauncherPreferences.PREF_GYRO_SENSITIVITY;
+        int damperWindow = LauncherPreferences.PREF_GYRO_DAMPER_WINDOW;
 
         //Triggers a write for some reason which resets the value
         addPreferencesFromResource(R.xml.pref_control);
@@ -46,6 +47,11 @@ public class LauncherPreferenceControlFragment extends LauncherPreferenceFragmen
         seek6.setRange(25, 300);
         seek6.setValue((int)(mouseSpeed *100f));
         seek6.setSuffix(" %");
+
+        CustomSeekBarPreference gyroDamperWindow = findPreference("gyroDamperWindow");
+        gyroDamperWindow.setRange(0, 200);
+        gyroDamperWindow.setValue(damperWindow);
+        gyroDamperWindow.setSuffix(" ms");
 
         Context context = getContext();
         if(context != null) {

--- a/app_pojavlauncher/src/main/res/values/strings.xml
+++ b/app_pojavlauncher/src/main/res/values/strings.xml
@@ -363,4 +363,6 @@
     <string name="global_save_and_exit">Save and exit</string>
     <string name="global_yes">Yes</string>
     <string name="global_no">No</string>
+    <string name="preference_gyro_damper_window_title">Smoothing time</string>
+    <string name="preference_gyro_damper_window_description">Reduce jitter in exchange of latency. 0 to disable it</string>
 </resources>

--- a/app_pojavlauncher/src/main/res/xml/pref_control.xml
+++ b/app_pojavlauncher/src/main/res/xml/pref_control.xml
@@ -112,6 +112,12 @@
             android:summary="@string/preference_gyro_sample_rate_description"
             app2:selectable="false"
             app2:showSeekBarValue="true"/>
+        <net.kdt.pojavlaunch.prefs.CustomSeekBarPreference
+            android:key="gyroDamperWindow"
+            android:title="@string/preference_gyro_damper_window_title"
+            android:summary="@string/preference_gyro_damper_window_description"
+            app2:selectable="false"
+            app2:showSeekBarValue="true"/>
         <SwitchPreference
             android:key="gyroInvertX"
             android:title="@string/preference_gyro_invert_x_axis"


### PR DESCRIPTION
# Jitterless gyro update
I guess my day today is all about jitter, huh ?

I'm here with another update that needs some review and testing.

# Feature
The gyroscope jitter is being reduced by computing the moving average of all angle differences within less than 100 ms. This is made to prevent the accelerometer to be a little to optimistic about the position of the phone.

However, while this provide a much more stable output, this slightly increases control latency.



