### PR TITLE
Feat[gyro]: improve calibration and smoothing

### DIFF
--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/GyroControl.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/GyroControl.java
@@ -108,6 +108,7 @@ public class GyroControl implements SensorEventListener, GrabListener {
     /** Update the axis mapping in accordance to activity rotation, used for initial rotation */
     public void updateOrientation(){
         int rotation = mWindowManager.getDefaultDisplay().getRotation();
+        mSurfaceRotation = rotation;
         switch (rotation){
             case Surface.ROTATION_0:
                 mSwapXY = true;
@@ -189,16 +190,14 @@ public class GyroControl implements SensorEventListener, GrabListener {
             // Force to wait to be in game before setting factors
             // Theoretically, one could use the whole interface in portrait...
             if(!mShouldHandleEvents) return;
-            int surfaceRotation = mWindowManager.getDefaultDisplay().getRotation();
-            if(surfaceRotation == mSurfaceRotation) return;
 
             if(i == OrientationEventListener.ORIENTATION_UNKNOWN) {
                 return; //change nothing
             }
-            mSurfaceRotation = surfaceRotation;
 
 
-            switch (mWindowManager.getDefaultDisplay().getRotation()){
+
+            switch (mSurfaceRotation){
                 case Surface.ROTATION_90:
                 case Surface.ROTATION_270:
                     mSwapXY = false;

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/GyroControl.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/GyroControl.java
@@ -90,12 +90,12 @@ public class GyroControl implements SensorEventListener, GrabListener {
         }
         SensorManager.getAngleChange(mAngleDifference, mCurrentRotation, mPreviousRotation);
         damperValue(mAngleDifference);
-        mStoredX += xAverage * 1000;
-        mStoredY += yAverage * 1000;
+        mStoredX += xAverage * 1000 * LauncherPreferences.PREF_GYRO_SENSITIVITY;
+        mStoredY += yAverage * 1000 * LauncherPreferences.PREF_GYRO_SENSITIVITY;
 
         if(Math.abs(mStoredX) + Math.abs(mStoredY) > REALLY_LOW_PASS_THRESHOLD){
-            CallbackBridge.mouseX -= ((mSwapXY ? mStoredY : mStoredX)  * LauncherPreferences.PREF_GYRO_SENSITIVITY * xFactor);
-            CallbackBridge.mouseY += ((mSwapXY ? mStoredX : mStoredY) * LauncherPreferences.PREF_GYRO_SENSITIVITY * yFactor);
+            CallbackBridge.mouseX -= ((mSwapXY ? mStoredY : mStoredX) * xFactor);
+            CallbackBridge.mouseY += ((mSwapXY ? mStoredX : mStoredY) * yFactor);
             CallbackBridge.sendCursorPos(CallbackBridge.mouseX, CallbackBridge.mouseY);
 
             mStoredX = 0;

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/GyroControl.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/GyroControl.java
@@ -20,7 +20,7 @@ import java.util.Arrays;
 
 public class GyroControl implements SensorEventListener, GrabListener {
     /* How much distance has to be moved before taking into account the gyro */
-    private static final float REALLY_LOW_PASS_THRESHOLD = 1.4F;
+    private static final float REALLY_LOW_PASS_THRESHOLD = 1.3F;
 
     private final WindowManager mWindowManager;
     private int mSurfaceRotation;

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/GyroControl.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/GyroControl.java
@@ -1,11 +1,5 @@
 package net.kdt.pojavlaunch;
 
-import static android.view.Surface.ROTATION_0;
-import static android.view.Surface.ROTATION_180;
-import static android.view.Surface.ROTATION_270;
-import static android.view.Surface.ROTATION_90;
-import static net.kdt.pojavlaunch.prefs.LauncherPreferences.PREF_GYRO_SAMPLE_RATE;
-
 import android.app.Activity;
 import android.content.Context;
 import android.hardware.Sensor;
@@ -13,6 +7,7 @@ import android.hardware.SensorEvent;
 import android.hardware.SensorEventListener;
 import android.hardware.SensorManager;
 import android.view.OrientationEventListener;
+import android.view.Surface;
 import android.view.WindowManager;
 
 import net.kdt.pojavlaunch.prefs.LauncherPreferences;
@@ -68,7 +63,7 @@ public class GyroControl implements SensorEventListener, GrabListener {
     public void enable() {
         if(mSensor == null) return;
         mFirstPass = true;
-        mSensorManager.registerListener(this, mSensor, 1000 * PREF_GYRO_SAMPLE_RATE);
+        mSensorManager.registerListener(this, mSensor, 1000 * LauncherPreferences.PREF_GYRO_SAMPLE_RATE);
         mCorrectionListener.enable();
         mShouldHandleEvents = CallbackBridge.isGrabbing();
         CallbackBridge.addGrabListener(this);
@@ -114,22 +109,22 @@ public class GyroControl implements SensorEventListener, GrabListener {
     public void updateOrientation(){
         int rotation = mWindowManager.getDefaultDisplay().getRotation();
         switch (rotation){
-            case ROTATION_0:
+            case Surface.ROTATION_0:
                 mSwapXY = true;
                 xFactor = 1;
                 yFactor = 1;
                 break;
-            case ROTATION_90:
+            case Surface.ROTATION_90:
                 mSwapXY = false;
                 xFactor = -1;
                 yFactor = 1;
                 break;
-            case ROTATION_180:
+            case Surface.ROTATION_180:
                 mSwapXY = true;
                 xFactor = -1;
                 yFactor = -1;
                 break;
-            case ROTATION_270:
+            case Surface.ROTATION_270:
                 mSwapXY = false;
                 xFactor = 1;
                 yFactor = -1;
@@ -201,11 +196,11 @@ public class GyroControl implements SensorEventListener, GrabListener {
                 return; //change nothing
             }
             mSurfaceRotation = surfaceRotation;
-            System.out.println(i);
+
 
             switch (mWindowManager.getDefaultDisplay().getRotation()){
-                case ROTATION_90:
-                case ROTATION_270:
+                case Surface.ROTATION_90:
+                case Surface.ROTATION_270:
                     mSwapXY = false;
                     if(225 <  i && i < 315) {
                         xFactor = -1;
@@ -216,8 +211,8 @@ public class GyroControl implements SensorEventListener, GrabListener {
                     }
                     break;
 
-                case ROTATION_0:
-                case ROTATION_180:
+                case Surface.ROTATION_0:
+                case Surface.ROTATION_180:
                     mSwapXY = true;
                     if((315 < i && i <= 360) || (i < 45) ) {
                         xFactor = 1;

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/GyroControl.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/GyroControl.java
@@ -70,7 +70,7 @@ public class GyroControl implements SensorEventListener, GrabListener {
         // Copy the old array content
         System.arraycopy(mCurrentRotation, 0, mPreviousRotation, 0, 16);
         SensorManager.getRotationMatrixFromVector(mCurrentRotation, sensorEvent.values);
-        System.out.println(Arrays.toString(sensorEvent.values));
+        
 
         if(mFirstPass){  // Setup initial position
             mFirstPass = false;

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/GyroControl.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/GyroControl.java
@@ -18,7 +18,7 @@ import java.util.Arrays;
 
 public class GyroControl implements SensorEventListener, GrabListener {
     /* How much distance has to be moved before taking into account the gyro */
-    private static final float SINGLE_AXIS_LOW_PASS_THRESHOLD = 1.1F;
+    private static final float SINGLE_AXIS_LOW_PASS_THRESHOLD = 1.13F;
     private static final float MULTI_AXIS_LOW_PASS_THRESHOLD = 1.3F;
 
     private final WindowManager mWindowManager;

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MainActivity.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MainActivity.java
@@ -279,6 +279,7 @@ public class MainActivity extends BaseActivity implements ControlButtonMenuListe
     public void onConfigurationChanged(@NonNull Configuration newConfig) {
         super.onConfigurationChanged(newConfig);
 
+        if(mGyroControl != null) mGyroControl.updateOrientation();
         Tools.updateWindowSize(this);
         minecraftGLView.refreshSize();
         runOnUiThread(() -> mControlLayout.refreshControlButtonPositions());

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/LauncherPreferences.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/LauncherPreferences.java
@@ -49,6 +49,7 @@ public class LauncherPreferences {
     public static boolean PREF_ENABLE_GYRO = false;
     public static float PREF_GYRO_SENSITIVITY = 1f;
     public static int PREF_GYRO_SAMPLE_RATE = 16;
+    public static int PREF_GYRO_DAMPER_WINDOW = 100;
 
     public static boolean PREF_GYRO_INVERT_X = false;
 
@@ -93,6 +94,7 @@ public class LauncherPreferences {
         PREF_ENABLE_GYRO = DEFAULT_PREF.getBoolean("enableGyro", false);
         PREF_GYRO_SENSITIVITY = ((float)DEFAULT_PREF.getInt("gyroSensitivity", 100))/100f;
         PREF_GYRO_SAMPLE_RATE = DEFAULT_PREF.getInt("gyroSampleRate", 16);
+        PREF_GYRO_DAMPER_WINDOW = DEFAULT_PREF.getInt("gyroDamperWindow", 100);
         PREF_GYRO_INVERT_X = DEFAULT_PREF.getBoolean("gyroInvertX", false);
         PREF_GYRO_INVERT_Y = DEFAULT_PREF.getBoolean("gyroInvertY", false);
         PREF_FORCE_VSYNC = DEFAULT_PREF.getBoolean("force_vsync", false);

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/LauncherPreferences.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/LauncherPreferences.java
@@ -49,7 +49,7 @@ public class LauncherPreferences {
     public static boolean PREF_ENABLE_GYRO = false;
     public static float PREF_GYRO_SENSITIVITY = 1f;
     public static int PREF_GYRO_SAMPLE_RATE = 16;
-    public static int PREF_GYRO_DAMPER_WINDOW = 100;
+    public static boolean PREF_GYRO_SMOOTHING = true;
 
     public static boolean PREF_GYRO_INVERT_X = false;
 
@@ -60,6 +60,7 @@ public class LauncherPreferences {
     public static boolean PREF_DUMP_SHADERS = false;
     public static float PREF_DEADZONE_SCALE = 1f;
     public static boolean PREF_BIG_CORE_AFFINITY = false;
+
 
 
     public static void loadPreferences(Context ctx) {
@@ -94,7 +95,7 @@ public class LauncherPreferences {
         PREF_ENABLE_GYRO = DEFAULT_PREF.getBoolean("enableGyro", false);
         PREF_GYRO_SENSITIVITY = ((float)DEFAULT_PREF.getInt("gyroSensitivity", 100))/100f;
         PREF_GYRO_SAMPLE_RATE = DEFAULT_PREF.getInt("gyroSampleRate", 16);
-        PREF_GYRO_DAMPER_WINDOW = DEFAULT_PREF.getInt("gyroDamperWindow", 100);
+        PREF_GYRO_SMOOTHING = DEFAULT_PREF.getBoolean("gyroSmoothing", true);
         PREF_GYRO_INVERT_X = DEFAULT_PREF.getBoolean("gyroInvertX", false);
         PREF_GYRO_INVERT_Y = DEFAULT_PREF.getBoolean("gyroInvertY", false);
         PREF_FORCE_VSYNC = DEFAULT_PREF.getBoolean("force_vsync", false);

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/screens/LauncherPreferenceControlFragment.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/screens/LauncherPreferenceControlFragment.java
@@ -89,6 +89,7 @@ public class LauncherPreferenceControlFragment extends LauncherPreferenceFragmen
         findPreference("gyroSampleRate").setVisible(LauncherPreferences.PREF_ENABLE_GYRO);
         findPreference("gyroInvertX").setVisible(LauncherPreferences.PREF_ENABLE_GYRO);
         findPreference("gyroInvertY").setVisible(LauncherPreferences.PREF_ENABLE_GYRO);
+        findPreference("gyroSmoothing").setVisible(LauncherPreferences.PREF_ENABLE_GYRO);
     }
 
 }

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/screens/LauncherPreferenceControlFragment.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/screens/LauncherPreferenceControlFragment.java
@@ -24,6 +24,7 @@ public class LauncherPreferenceControlFragment extends LauncherPreferenceFragmen
         float mouseSpeed = LauncherPreferences.PREF_MOUSESPEED;
         float gyroSpeed = LauncherPreferences.PREF_GYRO_SENSITIVITY;
         float joystickDeadzone = LauncherPreferences.PREF_DEADZONE_SCALE;
+        int damperWindow = LauncherPreferences.PREF_GYRO_DAMPER_WINDOW;
 
         //Triggers a write for some reason which resets the value
         addPreferencesFromResource(R.xml.pref_control);
@@ -52,6 +53,11 @@ public class LauncherPreferenceControlFragment extends LauncherPreferenceFragmen
         deadzoneSeek.setRange(50, 200);
         deadzoneSeek.setValue((int) joystickDeadzone * 100);
         deadzoneSeek.setSuffix(" %");
+
+        CustomSeekBarPreference gyroDamperWindow = findPreference("gyroDamperWindow");
+        gyroDamperWindow.setRange(0, 200);
+        gyroDamperWindow.setValue(damperWindow);
+        gyroDamperWindow.setSuffix(" ms");
 
         Context context = getContext();
         if(context != null) {

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/screens/LauncherPreferenceControlFragment.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/screens/LauncherPreferenceControlFragment.java
@@ -24,7 +24,7 @@ public class LauncherPreferenceControlFragment extends LauncherPreferenceFragmen
         float mouseSpeed = LauncherPreferences.PREF_MOUSESPEED;
         float gyroSpeed = LauncherPreferences.PREF_GYRO_SENSITIVITY;
         float joystickDeadzone = LauncherPreferences.PREF_DEADZONE_SCALE;
-        int damperWindow = LauncherPreferences.PREF_GYRO_DAMPER_WINDOW;
+
 
         //Triggers a write for some reason which resets the value
         addPreferencesFromResource(R.xml.pref_control);
@@ -54,10 +54,6 @@ public class LauncherPreferenceControlFragment extends LauncherPreferenceFragmen
         deadzoneSeek.setValue((int) joystickDeadzone * 100);
         deadzoneSeek.setSuffix(" %");
 
-        CustomSeekBarPreference gyroDamperWindow = findPreference("gyroDamperWindow");
-        gyroDamperWindow.setRange(0, 200);
-        gyroDamperWindow.setValue(damperWindow);
-        gyroDamperWindow.setSuffix(" ms");
 
         Context context = getContext();
         if(context != null) {

--- a/app_pojavlauncher/src/main/res/values/strings.xml
+++ b/app_pojavlauncher/src/main/res/values/strings.xml
@@ -367,12 +367,14 @@
     <string name="global_save_and_exit">Save and exit</string>
     <string name="global_yes">Yes</string>
     <string name="global_no">No</string>
+
     <string name="preference_controller_map_wiped">The controller config has been wiped</string>
     <string name="preference_category_controller_settings">Controller settings</string>
     <string name="preference_wipe_controller_title">Reset controller mapping</string>
     <string name="preference_wipe_controller_description">Allow you to remap the controller buttons</string>
     <string name="preference_deadzone_scale_title">Joystick deadzone scale</string>
     <string name="preference_deadzone_scale_description">Increase it if the joystick drifts</string>
+
     <string name="preference_force_big_core_title">Force renderer to run on the big core</string>
     <string name="preference_force_big_core_desc">Forces the Minecraft render thread to run on the core with the highest max frequency</string>
     <string name="version_select_hint">Select a version</string>
@@ -395,4 +397,9 @@
     <string name="of_dl_failed_to_scrape">Failed to collect data for OptiFine installation</string>
     <string name="of_dl_progress">Downloading %s</string>
     <string name="create_profile_optifine">Create OptiFine profile</string>
+
+
+    <string name="preference_gyro_damper_window_title">Smoothing time</string>
+    <string name="preference_gyro_damper_window_description">Reduce jitter in exchange of latency. 0 to disable it</string>
+
 </resources>

--- a/app_pojavlauncher/src/main/res/values/strings.xml
+++ b/app_pojavlauncher/src/main/res/values/strings.xml
@@ -302,6 +302,8 @@
     <string name="preference_gyro_invert_y_axis">Invert Y axis</string>
     <string name="preference_gyro_invert_x_axis_description">Invert the horizontal axis</string>
     <string name="preference_gyro_invert_y_axis_description">Invert the vertical axis</string>
+    <string name="preference_gyro_smoothing_title">Enable gyro smoothing</string>
+    <string name="preference_gyro_smoothing_description">Reduce jitter in exchange of latency.</string>
 
     <string name="preference_back_title">Back to the last screen</string>
     <string name="gles_hack_none">Don\'t shrink textures</string>
@@ -375,6 +377,7 @@
     <string name="preference_deadzone_scale_title">Joystick deadzone scale</string>
     <string name="preference_deadzone_scale_description">Increase it if the joystick drifts</string>
 
+
     <string name="preference_force_big_core_title">Force renderer to run on the big core</string>
     <string name="preference_force_big_core_desc">Forces the Minecraft render thread to run on the core with the highest max frequency</string>
     <string name="version_select_hint">Select a version</string>
@@ -401,5 +404,6 @@
 
     <string name="preference_gyro_damper_window_title">Smoothing time</string>
     <string name="preference_gyro_damper_window_description">Reduce jitter in exchange of latency. 0 to disable it</string>
+
 
 </resources>

--- a/app_pojavlauncher/src/main/res/xml/pref_control.xml
+++ b/app_pojavlauncher/src/main/res/xml/pref_control.xml
@@ -112,6 +112,12 @@
             android:summary="@string/preference_gyro_sample_rate_description"
             app2:selectable="false"
             app2:showSeekBarValue="true"/>
+        <net.kdt.pojavlaunch.prefs.CustomSeekBarPreference
+            android:key="gyroDamperWindow"
+            android:title="@string/preference_gyro_damper_window_title"
+            android:summary="@string/preference_gyro_damper_window_description"
+            app2:selectable="false"
+            app2:showSeekBarValue="true"/>
         <SwitchPreference
             android:key="gyroInvertX"
             android:title="@string/preference_gyro_invert_x_axis"

--- a/app_pojavlauncher/src/main/res/xml/pref_control.xml
+++ b/app_pojavlauncher/src/main/res/xml/pref_control.xml
@@ -112,12 +112,12 @@
             android:summary="@string/preference_gyro_sample_rate_description"
             app2:selectable="false"
             app2:showSeekBarValue="true"/>
-        <net.kdt.pojavlaunch.prefs.CustomSeekBarPreference
-            android:key="gyroDamperWindow"
-            android:title="@string/preference_gyro_damper_window_title"
-            android:summary="@string/preference_gyro_damper_window_description"
-            app2:selectable="false"
-            app2:showSeekBarValue="true"/>
+        <SwitchPreferenceCompat
+            android:key="gyroSmoothing"
+            android:title="@string/preference_gyro_smoothing_title"
+            android:summary="@string/preference_gyro_smoothing_description"
+            android:defaultValue="true"
+            />
         <SwitchPreference
             android:key="gyroInvertX"
             android:title="@string/preference_gyro_invert_x_axis"


### PR DESCRIPTION
# Better gyroscope
*PR reopened with additional changes*
*Please squash before merging*


# Features

## Smoothing
The gyroscope data can now be smoothed by... 1 more frame of data. It has the most impact for minimal latency.
This is an opt-out behavior, as many gyroscopes can be jittery.

The gyroscope also has a low pass store and release filter, do avoid sub-pixel jitter. This makes camera movement more predictable. 

## No calibration setup
When launching minecraft from the wrong orientation, the gyroscope axis could be messed up. This shouldn't be the case anymore




