### PR TITLE
Feat: Handle MainActivity destruction

### DIFF
--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/JavaGUILauncherActivity.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/JavaGUILauncherActivity.java
@@ -1,7 +1,5 @@
 package net.kdt.pojavlaunch;
 
-import static net.kdt.pojavlaunch.MainActivity.fullyExit;
-
 import android.annotation.SuppressLint;
 import android.content.ClipboardManager;
 import android.os.Bundle;
@@ -173,14 +171,10 @@ public class JavaGUILauncherActivity extends BaseActivity implements View.OnTouc
             openLogOutput(null);
             new Thread(() -> {
                 try {
-                    final int exit = doCustomInstall(runtime, modFile, javaArgs);
-                    Logger.appendToLog(getString(R.string.toast_optifine_success));
-                    if (exit != 0) return;
-                    runOnUiThread(() -> {
-                        Toast.makeText(JavaGUILauncherActivity.this, R.string.toast_optifine_success, Toast.LENGTH_SHORT).show();
-                        fullyExit();
-                    });
-
+                    // Due to time, the code here became, like, actually useless
+                    // So it was removed
+                    // Tbh this whole class needs a refactor...
+                    doCustomInstall(runtime, modFile, javaArgs);
                 } catch (Throwable e) {
                     Logger.appendToLog("Install failed:");
                     Logger.appendToLog(Log.getStackTraceString(e));
@@ -287,7 +281,7 @@ public class JavaGUILauncherActivity extends BaseActivity implements View.OnTouc
                 Toast.LENGTH_SHORT).show();
     }
 
-    public int launchJavaRuntime(Runtime runtime, File modFile, String javaArgs) {
+    public void launchJavaRuntime(Runtime runtime, File modFile, String javaArgs) {
         JREUtils.redirectAndPrintJRELog();
         try {
             List<String> javaArgList = new ArrayList<>();
@@ -313,18 +307,17 @@ public class JavaGUILauncherActivity extends BaseActivity implements View.OnTouc
 
             Logger.appendToLog("Info: Java arguments: " + Arrays.toString(javaArgList.toArray(new String[0])));
 
-            return JREUtils.launchJavaVM(this, runtime,null,javaArgList, LauncherPreferences.PREF_CUSTOM_JAVA_ARGS);
+            JREUtils.launchJavaVM(this, runtime,null,javaArgList, LauncherPreferences.PREF_CUSTOM_JAVA_ARGS);
         } catch (Throwable th) {
             Tools.showError(this, th, true);
-            return -1;
         }
     }
 
 
 
-    private int doCustomInstall(Runtime runtime, File modFile, String javaArgs) {
+    private void doCustomInstall(Runtime runtime, File modFile, String javaArgs) {
         mSkipDetectMod = true;
-        return launchJavaRuntime(runtime, modFile, javaArgs);
+        launchJavaRuntime(runtime, modFile, javaArgs);
     }
 
     public void toggleKeyboard(View view) {

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/LauncherActivity.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/LauncherActivity.java
@@ -23,7 +23,7 @@ import androidx.fragment.app.FragmentManager;
 import com.kdt.mcgui.ProgressLayout;
 import com.kdt.mcgui.mcAccountSpinner;
 
-import net.kdt.pojavlaunch.contextexecutor.ContextExecutor;
+import net.kdt.pojavlaunch.lifecycle.ContextExecutor;
 import net.kdt.pojavlaunch.contracts.OpenDocumentWithExtension;
 import net.kdt.pojavlaunch.extra.ExtraConstants;
 import net.kdt.pojavlaunch.extra.ExtraCore;
@@ -40,7 +40,7 @@ import net.kdt.pojavlaunch.progresskeeper.TaskCountListener;
 import net.kdt.pojavlaunch.services.ProgressServiceKeeper;
 import net.kdt.pojavlaunch.tasks.AsyncMinecraftDownloader;
 import net.kdt.pojavlaunch.tasks.AsyncVersionList;
-import net.kdt.pojavlaunch.tasks.ContextAwareDoneListener;
+import net.kdt.pojavlaunch.lifecycle.ContextAwareDoneListener;
 import net.kdt.pojavlaunch.utils.NotificationUtils;
 import net.kdt.pojavlaunch.value.launcherprofiles.LauncherProfiles;
 import net.kdt.pojavlaunch.value.launcherprofiles.MinecraftProfile;

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MainActivity.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MainActivity.java
@@ -350,6 +350,7 @@ public class MainActivity extends BaseActivity implements ControlButtonMenuListe
         int requiredJavaVersion = 8;
         if(version.javaVersion != null) requiredJavaVersion = version.javaVersion.majorVersion;
         Tools.launchMinecraft(this, minecraftAccount, minecraftProfile, versionId, requiredJavaVersion);
+        //Note that we actually stall in the above function, even if the game
         Tools.runOnUiThread(()-> mServiceBinder.isActive = false);
     }
 
@@ -630,9 +631,7 @@ public class MainActivity extends BaseActivity implements ControlButtonMenuListe
         GameService.LocalBinder localBinder = (GameService.LocalBinder) service;
         mServiceBinder = localBinder;
         minecraftGLView.start(localBinder.isActive);
-        if(!localBinder.isActive) {
-            localBinder.isActive = true;
-        }
+        localBinder.isActive = true;
     }
 
     @Override

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MainActivity.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MainActivity.java
@@ -350,7 +350,7 @@ public class MainActivity extends BaseActivity implements ControlButtonMenuListe
         int requiredJavaVersion = 8;
         if(version.javaVersion != null) requiredJavaVersion = version.javaVersion.majorVersion;
         Tools.launchMinecraft(this, minecraftAccount, minecraftProfile, versionId, requiredJavaVersion);
-        //Note that we actually stall in the above function, even if the game
+        //Note that we actually stall in the above function, even if the game crashes. But let's be safe.
         Tools.runOnUiThread(()-> mServiceBinder.isActive = false);
     }
 

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MinecraftGLSurface.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MinecraftGLSurface.java
@@ -145,14 +145,17 @@ public class MinecraftGLSurface extends View implements GrabListener {
         MCOptionUtils.addMCOptionListener(mGuiScaleListener);
     }
 
-    /** Initialize the view and all its settings */
-    public void start(){
+    /** Initialize the view and all its settings
+     * @param isAlreadyRunning set to true to tell the view that the game is already running
+     *                         (only updates the window without calling the start listener)
+     */
+    public void start(boolean isAlreadyRunning){
         if(LauncherPreferences.PREF_USE_ALTERNATE_SURFACE){
             SurfaceView surfaceView = new SurfaceView(getContext());
             mSurface = surfaceView;
 
             surfaceView.getHolder().addCallback(new SurfaceHolder.Callback() {
-                private boolean isCalled = false;
+                private boolean isCalled = isAlreadyRunning;
                 @Override
                 public void surfaceCreated(@NonNull SurfaceHolder holder) {
                     if(isCalled) {
@@ -181,7 +184,7 @@ public class MinecraftGLSurface extends View implements GrabListener {
             mSurface = textureView;
 
             textureView.setSurfaceTextureListener(new TextureView.SurfaceTextureListener() {
-                private boolean isCalled = false;
+                private boolean isCalled = isAlreadyRunning;
                 @Override
                 public void onSurfaceTextureAvailable(@NonNull SurfaceTexture surface, int width, int height) {
                     Surface tSurface = new Surface(surface);

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/PojavApplication.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/PojavApplication.java
@@ -18,7 +18,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
-import net.kdt.pojavlaunch.contextexecutor.ContextExecutor;
+import net.kdt.pojavlaunch.lifecycle.ContextExecutor;
 import net.kdt.pojavlaunch.tasks.AsyncAssetManager;
 import net.kdt.pojavlaunch.utils.*;
 

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/ShowErrorActivity.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/ShowErrorActivity.java
@@ -9,7 +9,7 @@ import android.os.Bundle;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import net.kdt.pojavlaunch.contextexecutor.ContextExecutorTask;
+import net.kdt.pojavlaunch.lifecycle.ContextExecutorTask;
 import net.kdt.pojavlaunch.utils.NotificationUtils;
 
 import java.io.Serializable;

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/Tools.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/Tools.java
@@ -167,6 +167,7 @@ public final class Tools {
         int freeDeviceMemory = getFreeDeviceMemory(activity);
         if(LauncherPreferences.PREF_RAM_ALLOCATION > freeDeviceMemory) {
             Object memoryErrorLock = new Object();
+            
             activity.runOnUiThread(() -> {
                 androidx.appcompat.app.AlertDialog.Builder b = new androidx.appcompat.app.AlertDialog.Builder(activity)
                         .setMessage(activity.getString(R.string.memory_warning_msg, freeDeviceMemory ,LauncherPreferences.PREF_RAM_ALLOCATION))

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/lifecycle/ContextAwareDoneListener.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/lifecycle/ContextAwareDoneListener.java
@@ -1,4 +1,4 @@
-package net.kdt.pojavlaunch.tasks;
+package net.kdt.pojavlaunch.lifecycle;
 
 import static net.kdt.pojavlaunch.MainActivity.INTENT_MINECRAFT_VERSION;
 
@@ -9,9 +9,10 @@ import android.content.Intent;
 import net.kdt.pojavlaunch.MainActivity;
 import net.kdt.pojavlaunch.R;
 import net.kdt.pojavlaunch.Tools;
-import net.kdt.pojavlaunch.contextexecutor.ContextExecutor;
-import net.kdt.pojavlaunch.contextexecutor.ContextExecutorTask;
+import net.kdt.pojavlaunch.lifecycle.ContextExecutor;
+import net.kdt.pojavlaunch.lifecycle.ContextExecutorTask;
 import net.kdt.pojavlaunch.progresskeeper.ProgressKeeper;
+import net.kdt.pojavlaunch.tasks.AsyncMinecraftDownloader;
 import net.kdt.pojavlaunch.utils.NotificationUtils;
 
 public class ContextAwareDoneListener implements AsyncMinecraftDownloader.DoneListener, ContextExecutorTask {

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/lifecycle/ContextExecutor.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/lifecycle/ContextExecutor.java
@@ -1,4 +1,4 @@
-package net.kdt.pojavlaunch.contextexecutor;
+package net.kdt.pojavlaunch.lifecycle;
 
 import android.app.Activity;
 import android.app.Application;

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/lifecycle/ContextExecutorTask.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/lifecycle/ContextExecutorTask.java
@@ -1,4 +1,4 @@
-package net.kdt.pojavlaunch.contextexecutor;
+package net.kdt.pojavlaunch.lifecycle;
 
 import android.app.Activity;
 import android.content.Context;

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/lifecycle/LifecycleAwareAlertDialog.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/lifecycle/LifecycleAwareAlertDialog.java
@@ -1,0 +1,80 @@
+package net.kdt.pojavlaunch.lifecycle;
+
+import android.content.Context;
+import android.content.DialogInterface;
+
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AlertDialog;
+import androidx.lifecycle.Lifecycle;
+import androidx.lifecycle.LifecycleEventObserver;
+import androidx.lifecycle.LifecycleOwner;
+
+/**
+ * A class that implements a form of lifecycle awareness for AlertDialog
+ */
+public abstract class LifecycleAwareAlertDialog implements LifecycleEventObserver {
+    private Lifecycle mLifecycle;
+    private AlertDialog mDialog;
+    private boolean mLifecycleEnded = false;
+
+    /**
+     * Show the lifecycle-aware dialog.
+     * @param lifecycle the lifecycle to follow
+     * @param context the context for the dialog
+     */
+    public void show(Lifecycle lifecycle, Context context) {
+        this.mLifecycleEnded = false;
+        this.mLifecycle = lifecycle;
+        if(mLifecycle.getCurrentState().equals(Lifecycle.State.DESTROYED)) {
+            this.mLifecycleEnded = true;
+            dialogHidden(mLifecycleEnded);
+            return;
+        }
+        AlertDialog.Builder builder = new AlertDialog.Builder(context);
+        // Install the default cancel/dismiss handling
+        builder.setOnDismissListener(wrapDismissListener(null));
+        createDialog(builder);
+        mLifecycle.addObserver(this);
+        mDialog = builder.show();
+    }
+
+    /**
+     * Invoked by the show() method to create the dialog. Note that any dismiss listeners
+     * added to the dialog must be wrapped with wrapDismissLisener.
+     * @param dialogBuilder the dialog builder used for building the dialog
+     */
+    abstract protected void createDialog(AlertDialog.Builder dialogBuilder);
+
+    /**
+     * Invoked when the dialog gets hidden either by cancel()/dismiss(), or if a lifecycle event
+     * happens.
+     * @param lifecycleEnded if the dialog was hidden due to a lifecycle event
+     */
+    abstract protected void dialogHidden(boolean lifecycleEnded);
+
+    protected void dispatchDialogHidden() {
+        new Exception().printStackTrace();
+        dialogHidden(mLifecycleEnded);
+        mLifecycle.removeObserver(this);
+    }
+
+    public void onStateChanged(@NonNull LifecycleOwner source, @NonNull Lifecycle.Event event) {
+        if(event.equals(Lifecycle.Event.ON_DESTROY)) {
+            mDialog.dismiss();
+            mLifecycleEnded = true;
+        }
+    }
+
+    /**
+     * Wrap an OnDismissListener for use with this LifecycleAwareAlertDialog. Pass null to only invoke the
+     * default dialog hidden handling.
+     * @param listener your listener
+     * @return the wrapped listener
+     */
+    protected DialogInterface.OnDismissListener wrapDismissListener(DialogInterface.OnCancelListener listener) {
+        return dialog -> {
+            dispatchDialogHidden();
+            if(listener != null) listener.onCancel(dialog);
+        };
+    }
+}

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/mirrors/MirrorTamperedException.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/mirrors/MirrorTamperedException.java
@@ -7,7 +7,7 @@ import android.text.Html;
 
 import net.kdt.pojavlaunch.R;
 import net.kdt.pojavlaunch.ShowErrorActivity;
-import net.kdt.pojavlaunch.contextexecutor.ContextExecutorTask;
+import net.kdt.pojavlaunch.lifecycle.ContextExecutorTask;
 import net.kdt.pojavlaunch.prefs.LauncherPreferences;
 
 public class MirrorTamperedException extends Exception implements ContextExecutorTask {

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/services/GameService.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/services/GameService.java
@@ -1,10 +1,7 @@
 package net.kdt.pojavlaunch.services;
 
-import android.app.Activity;
-import android.app.Application;
 import android.app.PendingIntent;
 import android.app.Service;
-import android.content.Context;
 import android.content.Intent;
 import android.os.Binder;
 import android.os.Build;
@@ -14,10 +11,8 @@ import android.os.Process;
 import androidx.annotation.Nullable;
 import androidx.core.app.NotificationCompat;
 
-import net.kdt.pojavlaunch.MainActivity;
 import net.kdt.pojavlaunch.R;
 import net.kdt.pojavlaunch.Tools;
-import net.kdt.pojavlaunch.contextexecutor.ContextExecutorTask;
 import net.kdt.pojavlaunch.utils.NotificationUtils;
 
 import java.lang.ref.WeakReference;
@@ -66,45 +61,6 @@ public class GameService extends Service {
     }
 
     public static class LocalBinder extends Binder {
-        public Throwable throwable;
-        private MainActivity mMainActivity;
-        private ContextExecutorTask mActivityRunnable;
-        public void notifyThrowable(Throwable throwable) {
-            Tools.runOnUiThread(()->{
-                if(mMainActivity != null) {
-                    Tools.showError(mMainActivity.getBaseContext(), throwable);
-                    return;
-                }
-                this.throwable = throwable;
-            });
-        }
-        public void attachGameActivity(MainActivity mainActivity) {
-            mMainActivity = mainActivity;
-            if(throwable != null) {
-                Tools.showError(mMainActivity.getBaseContext(), throwable, true);
-                throwable = null;
-            }
-            if(mActivityRunnable != null)
-                mActivityRunnable.executeWithActivity(mainActivity);
-
-        }
-        public void detachGameActivity() {
-            mMainActivity = null;
-        }
         public boolean isActive;
-    }
-    public static abstract class MainActivityDialogTask implements ContextExecutorTask {
-        private final LocalBinder mLocalBinder;
-        protected MainActivityDialogTask(LocalBinder mLocalBinder) {
-            this.mLocalBinder = mLocalBinder;
-        }
-        public abstract void executeWithActivity(Activity activity);
-        @Override
-        public void executeWithApplication(Context application) {
-            mLocalBinder.mActivityRunnable = this;
-        }
-        protected void detach() {
-            mLocalBinder.mActivityRunnable = null;
-        }
     }
 }

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/services/GameService.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/services/GameService.java
@@ -1,29 +1,30 @@
 package net.kdt.pojavlaunch.services;
 
+import android.app.Activity;
+import android.app.Application;
 import android.app.PendingIntent;
 import android.app.Service;
 import android.content.Context;
 import android.content.Intent;
+import android.os.Binder;
 import android.os.Build;
 import android.os.IBinder;
 import android.os.Process;
 
 import androidx.annotation.Nullable;
 import androidx.core.app.NotificationCompat;
-import androidx.core.content.ContextCompat;
 
+import net.kdt.pojavlaunch.MainActivity;
 import net.kdt.pojavlaunch.R;
 import net.kdt.pojavlaunch.Tools;
+import net.kdt.pojavlaunch.contextexecutor.ContextExecutorTask;
 import net.kdt.pojavlaunch.utils.NotificationUtils;
 
 import java.lang.ref.WeakReference;
 
 public class GameService extends Service {
     private static final WeakReference<Service> sGameService = new WeakReference<>(null);
-    public static void startService(Context context) {
-        Intent intent = new Intent(context, GameService.class);
-        ContextCompat.startForegroundService(context, intent);
-    }
+    private final LocalBinder mLocalBinder = new LocalBinder();
 
     @Override
     public void onCreate() {
@@ -47,7 +48,7 @@ public class GameService extends Service {
                 .addAction(android.R.drawable.ic_menu_close_clear_cancel,  getString(R.string.notification_terminate), pendingKillIntent)
                 .setSmallIcon(R.drawable.notif_icon)
                 .setNotificationSilent();
-       startForeground(NotificationUtils.NOTIFICATION_ID_GAME_SERVICE, notificationBuilder.build());
+        startForeground(NotificationUtils.NOTIFICATION_ID_GAME_SERVICE, notificationBuilder.build());
         return START_NOT_STICKY; // non-sticky so android wont try restarting the game after the user uses the "Quit" button
     }
 
@@ -61,6 +62,49 @@ public class GameService extends Service {
     @Nullable
     @Override
     public IBinder onBind(Intent intent) {
-        return null;
+        return mLocalBinder;
+    }
+
+    public static class LocalBinder extends Binder {
+        public Throwable throwable;
+        private MainActivity mMainActivity;
+        private ContextExecutorTask mActivityRunnable;
+        public void notifyThrowable(Throwable throwable) {
+            Tools.runOnUiThread(()->{
+                if(mMainActivity != null) {
+                    Tools.showError(mMainActivity.getBaseContext(), throwable);
+                    return;
+                }
+                this.throwable = throwable;
+            });
+        }
+        public void attachGameActivity(MainActivity mainActivity) {
+            mMainActivity = mainActivity;
+            if(throwable != null) {
+                Tools.showError(mMainActivity.getBaseContext(), throwable, true);
+                throwable = null;
+            }
+            if(mActivityRunnable != null)
+                mActivityRunnable.executeWithActivity(mainActivity);
+
+        }
+        public void detachGameActivity() {
+            mMainActivity = null;
+        }
+        public boolean isActive;
+    }
+    public static abstract class MainActivityDialogTask implements ContextExecutorTask {
+        private final LocalBinder mLocalBinder;
+        protected MainActivityDialogTask(LocalBinder mLocalBinder) {
+            this.mLocalBinder = mLocalBinder;
+        }
+        public abstract void executeWithActivity(Activity activity);
+        @Override
+        public void executeWithApplication(Context application) {
+            mLocalBinder.mActivityRunnable = this;
+        }
+        protected void detach() {
+            mLocalBinder.mActivityRunnable = null;
+        }
     }
 }


### PR DESCRIPTION
This allows the launcher to handle MainActivity destruction more gracefully, without forcing a game restart while it is already running. This fixes the bug of not being able to return to the game after putting it into background on some devices.