### PR TITLE
Experimental fix: Chat disabled due to missing profile public key

### DIFF
--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/Tools.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/Tools.java
@@ -339,6 +339,9 @@ public final class Tools {
         }
 
         String userType = "mojang";
+        if (LauncherPreferences.PREF_FORCE_USER_TYPE_MSA) {
+            userType = "msa";
+        }
 
         Map<String, String> varArgMap = new ArrayMap<>();
         varArgMap.put("auth_session", profile.accessToken); // For legacy versions of MC

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/LauncherPreferences.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/LauncherPreferences.java
@@ -62,6 +62,7 @@ public class LauncherPreferences {
     public static boolean PREF_DUMP_SHADERS = false;
     public static float PREF_DEADZONE_SCALE = 1f;
     public static boolean PREF_BIG_CORE_AFFINITY = false;
+    public static boolean PREF_FORCE_USER_TYPE_MSA = false;
     public static boolean PREF_ZINK_PREFER_SYSTEM_DRIVER = false;
     
     public static boolean PREF_VERIFY_MANIFEST = true;
@@ -109,6 +110,7 @@ public class LauncherPreferences {
         PREF_DUMP_SHADERS = DEFAULT_PREF.getBoolean("dump_shaders", false);
         PREF_DEADZONE_SCALE = ((float) DEFAULT_PREF.getInt("gamepad_deadzone_scale", 100))/100f;
         PREF_BIG_CORE_AFFINITY = DEFAULT_PREF.getBoolean("bigCoreAffinity", false);
+        PREF_FORCE_USER_TYPE_MSA = DEFAULT_PREF.getBoolean("forceUserTypeMSA", false);
         PREF_ZINK_PREFER_SYSTEM_DRIVER = DEFAULT_PREF.getBoolean("zinkPreferSystemDriver", false);
         PREF_DOWNLOAD_SOURCE = DEFAULT_PREF.getString("downloadSource", "default");
         PREF_VERIFY_MANIFEST = DEFAULT_PREF.getBoolean("verifyManifest", true);

--- a/app_pojavlauncher/src/main/res/values/strings.xml
+++ b/app_pojavlauncher/src/main/res/values/strings.xml
@@ -367,4 +367,6 @@
     <string name="preference_vsync_in_zink_title">Allow V-Sync with Zink</string>
     <string name="preference_vsync_in_zink_description">Allows the launcher to use internal system APIs to enable V-Sync for Zink. Turn this off if your launcher suddenly crashes with Zink after a system update.</string>
     <string name="exception_failed_to_unpack_jre17">Failed to install JRE 17</string>
+    <string name="preference_force_user_type_msa_title">Force minecraft user type to MSA</string>
+    <string name="preference_force_user_type_msa_desc">Solve "Chat disabled due to missing profile public key" but might have side-effect.</string>
 </resources>

--- a/app_pojavlauncher/src/main/res/xml/pref_experimental.xml
+++ b/app_pojavlauncher/src/main/res/xml/pref_experimental.xml
@@ -14,6 +14,11 @@
             android:key="bigCoreAffinity"
             android:title="@string/preference_force_big_core_title"
             android:summary="@string/preference_force_big_core_desc" />
+        <SwitchPreference
+            android:defaultValue="false"
+            android:key="forceUserTypeMSA"
+            android:title="@string/preference_force_user_type_msa_title"
+            android:summary="@string/preference_force_user_type_msa_desc" />
 
     </PreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
this is added into experimental because i think it will have side-effect on lower version and/or local account.
#4855

i have tested this on minecraft 1.20 server:
when user type is mojang it show "Chat disabled due to missing profile public key".
when user type is msa it works