### PR TITLE
After using `calloc` instead of `malloc`, use `memset`

### DIFF
--- a/app_pojavlauncher/src/main/jni/environ/environ.c
+++ b/app_pojavlauncher/src/main/jni/environ/environ.c
@@ -12,9 +12,8 @@ __attribute__((constructor)) void env_init() {
     char* strptr_env = getenv("POJAV_ENVIRON");
     if(strptr_env == NULL) {
         __android_log_print(ANDROID_LOG_INFO, "Environ", "No environ found, creating...");
-        pojav_environ = malloc(sizeof(struct pojav_environ_s));
+        pojav_environ = calloc(sizeof(struct pojav_environ_s), 1);
         assert(pojav_environ);
-        memset(pojav_environ, 0 , sizeof(struct pojav_environ_s));
         if(asprintf(&strptr_env, "%p", pojav_environ) == -1) abort();
         setenv("POJAV_ENVIRON", strptr_env, 1);
         free(strptr_env);


### PR DESCRIPTION
After using `calloc` instead of `malloc`, use `memset`