### PR TITLE
Remove MCBBS game download source

### DIFF
--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/mirrors/DownloadMirror.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/mirrors/DownloadMirror.java
@@ -24,11 +24,6 @@ public class DownloadMirror {
             "https://bmclapi2.bangbang93.com",
             "https://bmclapi2.bangbang93.com/assets"
     };
-    private static final String[] MIRROR_MCBBS = {
-            "https://download.mcbbs.net/maven",
-            "https://download.mcbbs.net",
-            "https://download.mcbbs.net/assets"
-    };
 
     /**
      * Download a file with the current mirror. If the file is missing on the mirror,
@@ -83,7 +78,6 @@ public class DownloadMirror {
 
     private static String[] getMirrorSettings() {
         switch (LauncherPreferences.PREF_DOWNLOAD_SOURCE) {
-            case "mcbbs": return MIRROR_MCBBS;
             case "bmclapi": return MIRROR_BMCLAPI;
             case "default":
             default:

--- a/app_pojavlauncher/src/main/res/values/headings_array.xml
+++ b/app_pojavlauncher/src/main/res/values/headings_array.xml
@@ -43,12 +43,10 @@
     <string-array name="download_source_names">
         <item>@string/global_default</item>
         <item>BMCLAPI</item>
-        <item>MCBBS</item>
     </string-array>
     <string-array name="download_source_values">
         <item>default</item>
         <item>bmclapi</item>
-        <item>mcbbs</item>
     </string-array>
 
 </resources>


### PR DESCRIPTION
Due to the permanent closure of the MCBBS website, the MCBBS game download source, which was previously hosted by MCBBS, has permanently become inactive. Therefore, the MCBBS download source option is no longer supported and needs to be removed.