### PR TITLE
fix(gamepad): analog trigger treshold

### DIFF
--- a/app_pojavlauncher/build.gradle
+++ b/app_pojavlauncher/build.gradle
@@ -203,7 +203,7 @@ dependencies {
     implementation 'com.github.PojavLauncherTeam:portrait-sdp:ed33e89cbc'
     implementation 'com.github.PojavLauncherTeam:portrait-ssp:6c02fd739b'
     implementation 'com.github.Mathias-Boulay:ExtendedView:1.0.0'
-    implementation 'com.github.Mathias-Boulay:android_gamepad_remapper:a0fe7e72f2'
+    implementation 'com.github.Mathias-Boulay:android_gamepad_remapper:06184ddbce'
     implementation 'com.github.Mathias-Boulay:virtual-joystick-android:2e7aa25e50'
 
     // implementation 'com.intuit.sdp:sdp-android:1.0.5'


### PR DESCRIPTION
# What changed ?

## User facing
Analogue gamepad users should not have double block breaks

## Dev facing
Nothing much, the gamepad library has been updated.
