### PR TITLE
Fix: Default Controlmap & Custom Path Selection Conflict Resolved

### DIFF
--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/fragments/ProfileEditorFragment.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/fragments/ProfileEditorFragment.java
@@ -122,6 +122,8 @@ public class ProfileEditorFragment extends Fragment implements CropperUtils.Crop
             Bundle bundle = new Bundle(3);
             bundle.putBoolean(FileSelectorFragment.BUNDLE_SELECT_FOLDER, false);
             bundle.putString(FileSelectorFragment.BUNDLE_ROOT_PATH, Tools.CTRLMAP_PATH);
+            mValueToConsume = "select_file";
+
             Tools.swapFragment(requireActivity(),
                     FileSelectorFragment.class, FileSelectorFragment.TAG, bundle);
         });


### PR DESCRIPTION
When the user clicks the custom path selection button, the variable "mValueToConsume" records a value, which is used to distinguish whether the user selects a folder or a file. Based on this value, the application saves the path information in the corresponding location, i.e., the folder path is saved in the custom path, and the file path is saved in the default control layout path. However, this variable is only assigned a value when the user clicks the custom path selection button. If the user clicks the custom path selection button first and then clicks the default control layout selection button, it will result in the path of the control layout being incorrectly saved in the variable originally used for the custom game path.