### PR TITLE
Fix: username invalid character regular expression

### DIFF
--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/fragments/LocalLoginFragment.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/fragments/LocalLoginFragment.java
@@ -46,7 +46,7 @@ public class LocalLoginFragment extends Fragment {
         return !(text.isEmpty()
                 || text.length() < 3
                 || text.length() > 16
-                || !text.matches("\\w+")
+                || text.matches("[^a-zA-Z0-9_]")
                 || new File(Tools.DIR_ACCOUNT_NEW + "/" + text + ".json").exists()
         );
     }

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/fragments/LocalLoginFragment.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/fragments/LocalLoginFragment.java
@@ -14,6 +14,8 @@ import net.kdt.pojavlaunch.extra.ExtraConstants;
 import net.kdt.pojavlaunch.extra.ExtraCore;
 
 import java.io.File;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class LocalLoginFragment extends Fragment {
     public static final String TAG = "LOCAL_LOGIN_FRAGMENT";
@@ -43,10 +45,13 @@ public class LocalLoginFragment extends Fragment {
 
         String text = mUsernameEditText.getText().toString();
 
+        Pattern pattern = Pattern.compile("[^a-zA-Z0-9_]");
+        Matcher matcher = pattern.matcher(text);
+
         return !(text.isEmpty()
                 || text.length() < 3
                 || text.length() > 16
-                || text.matches("[^a-zA-Z0-9_]")
+                || matcher.find()
                 || new File(Tools.DIR_ACCOUNT_NEW + "/" + text + ".json").exists()
         );
     }


### PR DESCRIPTION
I'm not sure why the original regular expression couldn't exclude Chinese characters, but this new regular expression can correctly exclude Chinese characters.

https://github.com/PojavLauncherTeam/PojavLauncher/assets/123115192/f2c9e192-d16c-42aa-866c-9b72a45e8432

