### PR TITLE
Cleanup: Controls v3.1

### DIFF
--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/ControlData.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/ControlData.java
@@ -53,7 +53,7 @@ public class ControlData {
      * bigger device or vice versa.
      */
     public String dynamicX, dynamicY;
-    public boolean isDynamicBtn, isToggle, passThruEnabled;
+    public boolean isToggle, passThruEnabled;
     public String name;
     public int[] keycodes;      //Should store up to 4 keys
     public float opacity;       //Alpha value from 0 to 1;
@@ -93,7 +93,6 @@ public class ControlData {
 
     public ControlData(String name, int[] keycodes, float x, float y, float width, float height) {
         this(name, keycodes, Float.toString(x), Float.toString(y), width, height, false);
-        this.isDynamicBtn = false;
     }
 
     public ControlData(String name, int[] keycodes, String dynamicX, String dynamicY) {
@@ -119,7 +118,6 @@ public class ControlData {
         this.dynamicY = dynamicY;
         this.width = width;
         this.height = height;
-        this.isDynamicBtn = false;
         this.isToggle = isToggle;
         this.opacity = opacity;
         this.bgColor = bgColor;

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/ControlData.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/ControlData.java
@@ -44,7 +44,7 @@ public class ControlData {
     }
 
     // Internal usage only
-    public boolean isHideable;
+    public transient boolean isHideable;
     /**
      * Both fields below are dynamic position data, auto updates
      * X and Y position, unlike the original one which uses fixed

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/CustomControls.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/CustomControls.java
@@ -57,13 +57,13 @@ public class CustomControls {
 		this.mControlDataList.add(new ControlData(ctx, R.string.control_jump, new int[]{LwjglGlfwKeycode.GLFW_KEY_SPACE}, "${right} - ${margin} * 2 - ${width}", "${bottom} - ${margin} * 2 - ${height}", true));
 
 		//The default controls are conform to the V3
-		version = 6;
+		version = 7;
 	}
 
 	
 	public void save(String path) throws IOException {
-		//Current version is the V3.0 so the version as to be marked as 6 !
-		version = 6;
+		//Current version is the V3.1 so the version as to be marked as 7 !
+		version = 7;
 
 		Tools.write(path, Tools.GLOBAL_GSON.toJson(this));
 	}

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/LayoutConverter.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/LayoutConverter.java
@@ -105,7 +105,6 @@ public class LayoutConverter {
                     LwjglGlfwKeycode.GLFW_KEY_UNKNOWN,
                     LwjglGlfwKeycode.GLFW_KEY_UNKNOWN,
                     LwjglGlfwKeycode.GLFW_KEY_UNKNOWN};
-            n_button.isDynamicBtn = button.getBoolean("isDynamicBtn");
             n_button.dynamicX = button.getString("dynamicX");
             n_button.dynamicY = button.getString("dynamicY");
             if (!Tools.isValidString(n_button.dynamicX) && button.has("x")) {

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/buttons/ControlInterface.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/buttons/ControlInterface.java
@@ -371,13 +371,10 @@ public interface ControlInterface extends View.OnLongClickListener, GrabListener
                         if (Math.abs(event.getRawX() - downRawX) > 8 || Math.abs(event.getRawY() - downRawY) > 8)
                             mCanTriggerLongClick = false;
                         getControlLayoutParent().adaptPanelPosition();
-
-                        if (!getProperties().isDynamicBtn) {
-                            snapAndAlign(
-                                    MathUtils.clamp(event.getRawX() - downX, 0, CallbackBridge.physicalWidth - view.getWidth()),
-                                    MathUtils.clamp(event.getRawY() - downY, 0, CallbackBridge.physicalHeight - view.getHeight())
-                            );
-                        }
+                        snapAndAlign(
+                                MathUtils.clamp(event.getRawX() - downX, 0, CallbackBridge.physicalWidth - view.getWidth()),
+                                MathUtils.clamp(event.getRawY() - downY, 0, CallbackBridge.physicalHeight - view.getHeight())
+                        );
                         break;
                 }
 
@@ -393,13 +390,8 @@ public interface ControlInterface extends View.OnLongClickListener, GrabListener
             setBackground();
 
             // Re-calculate position
-            if (!getProperties().isDynamicBtn) {
-                getControlView().setX(getControlView().getX());
-                getControlView().setY(getControlView().getY());
-            } else {
-                getControlView().setX(getProperties().insertDynamicPos(getProperties().dynamicX));
-                getControlView().setY(getProperties().insertDynamicPos(getProperties().dynamicY));
-            }
+            getControlView().setX(getControlView().getX());
+            getControlView().setY(getControlView().getY());
         });
     }
 

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/buttons/ControlSubButton.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/buttons/ControlSubButton.java
@@ -26,7 +26,6 @@ public class ControlSubButton extends ControlButton {
             mProperties.setHeight(parentDrawer.getProperties().getHeight());
             mProperties.setWidth(parentDrawer.getProperties().getWidth());
         }
-        mProperties.isDynamicBtn = false;
 
         setProperties(mProperties, false);
     }


### PR DESCRIPTION
# Controls v3.1
This PR is mostly a cleanup, it nonetheless requires a control version bump.

## Fixes
- The display cutout is handled better for cutouts taller than wider, fixing the offset of controls  partially out  of the screen and the hotbar controls being slightly offset

## Technical changes
- Remove `isHideable` from the exported controls. This variable was never intended to be modified externally.
- Remove `isDynamicBtn` from the exported controls. This variable was hidden since controls v2 from the user and is now not used anymore.