### PR TITLE
Fix/tap detector

### DIFF
--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/mouse/TapDetector.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/mouse/TapDetector.java
@@ -22,7 +22,7 @@ public class TapDetector {
 
     private final static int TAP_MIN_DELTA_MS = 10;
     private final static int TAP_MAX_DELTA_MS = 300;
-    private final static int TAP_SLOP_SQUARE_PX = (int) Tools.dpToPx(2000);
+    private final static int TAP_SLOP_SQUARE_PX = (int) Tools.dpToPx(2500);
 
     private final int mTapNumberToDetect;
     private int mCurrentTapNumber = 0;

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/mouse/TapDetector.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/mouse/TapDetector.java
@@ -22,7 +22,7 @@ public class TapDetector {
 
     private final static int TAP_MIN_DELTA_MS = 10;
     private final static int TAP_MAX_DELTA_MS = 300;
-    private final static int TAP_SLOP_SQUARE_PX = (int) Math.pow(Tools.dpToPx(100), 2);
+    private final static int TAP_SLOP_SQUARE_PX = (int) Tools.dpToPx(2000);
 
     private final int mTapNumberToDetect;
     private int mCurrentTapNumber = 0;
@@ -83,13 +83,20 @@ public class TapDetector {
         if(mCurrentTapNumber > 0){
             if  ((deltaTime < TAP_MIN_DELTA_MS || deltaTime > TAP_MAX_DELTA_MS) ||
                 ((deltaX*deltaX + deltaY*deltaY) > TAP_SLOP_SQUARE_PX)) {
-                // We invalidate previous taps, not this one though
-                mCurrentTapNumber = 0;
+                if (mDetectionMethod == DETECTION_METHOD_BOTH && (eventAction == ACTION_UP || eventAction == ACTION_POINTER_UP)) {
+                    // For the both method, the user is expected to start with a down action.
+                    resetTapDetectionState();
+                    return false;
+                } else {
+                    // We invalidate previous taps, not this one though
+                    mCurrentTapNumber = 0;
+                }
             }
         }
 
         //A worthy tap happened
         mCurrentTapNumber += 1;
+        System.out.println("TapDetector: Tap detected: " + mCurrentTapNumber + " / " + mTapNumberToDetect + "; X: " +eventX + "; Y: " + eventY + "; Delta: " + (deltaX*deltaX + deltaY*deltaY) + "/"+ TAP_SLOP_SQUARE_PX );
         if(mCurrentTapNumber >= mTapNumberToDetect){
            resetTapDetectionState();
            return true;

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/mouse/TapDetector.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/mouse/TapDetector.java
@@ -96,7 +96,6 @@ public class TapDetector {
 
         //A worthy tap happened
         mCurrentTapNumber += 1;
-        System.out.println("TapDetector: Tap detected: " + mCurrentTapNumber + " / " + mTapNumberToDetect + "; X: " +eventX + "; Y: " + eventY + "; Delta: " + (deltaX*deltaX + deltaY*deltaY) + "/"+ TAP_SLOP_SQUARE_PX );
         if(mCurrentTapNumber >= mTapNumberToDetect){
            resetTapDetectionState();
            return true;


### PR DESCRIPTION
# What's in it ?
This small PR brings a few fixes for the tap detector

- Reduce the area considered valid for a click. In a previous optimization attempt, the area value ended up being overblown, allowing for ~260px of distance. This has been reduced to a more fitting ~80px
- For `DETECTION_METHOD_BOTH`, the user is expected to start by putting his finger down. Due to partial reset, it was able to start at a UP event. This is no longer the case.

Fixes #5470 