### PR TITLE
Fix: Inaccurate Modrinth source search results

### DIFF
--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/fragments/SearchModFragment.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/fragments/SearchModFragment.java
@@ -86,9 +86,7 @@ public class SearchModFragment extends Fragment implements ModItemAdapter.Search
         mRecyclerview.addOnScrollListener(mOverlayPositionListener);
 
         mSearchEditText.setOnEditorActionListener((v, actionId, event) -> {
-            mSearchProgressBar.setVisibility(View.VISIBLE);
-            mSearchFilters.name = mSearchEditText.getText().toString();
-            mModItemAdapter.performSearchQuery(mSearchFilters);
+            searchMods(mSearchEditText.getText().toString());
             mSearchEditText.clearFocus();
             return false;
         });
@@ -101,6 +99,8 @@ public class SearchModFragment extends Fragment implements ModItemAdapter.Search
                    mRecyclerview.getPaddingBottom());
         });
         mFilterButton.setOnClickListener(v -> displayFilterDialog());
+
+        searchMods(null);
     }
 
     @Override
@@ -132,6 +132,12 @@ public class SearchModFragment extends Fragment implements ModItemAdapter.Search
         }
     }
 
+    private void searchMods(String name) {
+        mSearchProgressBar.setVisibility(View.VISIBLE);
+        mSearchFilters.name = name == null ? "" : name;
+        mModItemAdapter.performSearchQuery(mSearchFilters);
+    }
+
     private void displayFilterDialog() {
         AlertDialog dialog = new AlertDialog.Builder(requireContext())
                 .setView(R.layout.dialog_mod_filters)
@@ -156,6 +162,7 @@ public class SearchModFragment extends Fragment implements ModItemAdapter.Search
             // Apply the new settings
             mApplyButton.setOnClickListener(v -> {
                 mSearchFilters.mcVersion = mSelectedVersion.getText().toString();
+                searchMods(mSearchEditText.getText().toString());
                 dialogInterface.dismiss();
             });
         });

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/modloaders/modpacks/api/ModrinthApi.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/modloaders/modpacks/api/ModrinthApi.java
@@ -50,7 +50,7 @@ public class ModrinthApi implements ModpackApi{
             facetString.append(String.format(",[\"versions:%s\"]", searchFilters.mcVersion));
         facetString.append("]");
         params.put("facets", facetString.toString());
-        params.put("query", searchFilters.name.replace(' ', '+'));
+        params.put("query", searchFilters.name);
         params.put("limit", 50);
         params.put("index", "relevance");
         if(modrinthSearchResult != null)


### PR DESCRIPTION
When constructing Modrinth search links, you should not manually replace all spaces with "+" symbols, as these "+" symbols will be converted to "%2B" strings in the final link, resulting in inaccurate search results. If left unmodified, the final search link will automatically replace all spaces with "+" symbols and will not be converted to "%2B" strings.