### PR TITLE
Fix: Inaccurate Modrinth source search results

### DIFF
--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/modloaders/modpacks/api/ModrinthApi.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/modloaders/modpacks/api/ModrinthApi.java
@@ -50,7 +50,7 @@ public class ModrinthApi implements ModpackApi{
             facetString.append(String.format(",[\"versions:%s\"]", searchFilters.mcVersion));
         facetString.append("]");
         params.put("facets", facetString.toString());
-        params.put("query", searchFilters.name.replace(' ', '+'));
+        params.put("query", searchFilters.name);
         params.put("limit", 50);
         params.put("index", "relevance");
         if(modrinthSearchResult != null)


### PR DESCRIPTION
When constructing Modrinth search links, you should not manually replace all spaces with "+" symbols, as these "+" symbols will be converted to "%2B" strings in the final link, resulting in inaccurate search results. If left unmodified, the final search link will automatically replace all spaces with "+" symbols and will not be converted to "%2B" strings.