### PR TITLE
Remove the ability to download Minecraft on Local accounts.

### DIFF
--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/LauncherActivity.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/LauncherActivity.java
@@ -132,6 +132,20 @@ public class LauncherActivity extends BaseActivity {
         }
         String normalizedVersionId = AsyncMinecraftDownloader.normalizeVersionId(prof.lastVersionId);
         JMinecraftVersionList.Version mcVersion = AsyncMinecraftDownloader.getListedVersion(normalizedVersionId);
+        if (mAccountSpinner.getSelectedAccount().isLocal()) {
+            AlertDialog.Builder builder = new AlertDialog.Builder(this);
+            builder.setTitle("Error");
+            builder.setMessage("Minecraft can't be legally installed when logged in with a local account. Please switch to an online account to continue.");
+            builder.setPositiveButton("OK", new DialogInterface.OnClickListener() {
+                @Override
+                public void onClick(DialogInterface dialog, int which) {
+                    dialog.dismiss();
+                }
+            });
+            AlertDialog dialog = builder.create();
+            dialog.show();
+            return false;
+        }
         new MinecraftDownloader().start(
                 this,
                 mcVersion,

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/LauncherActivity.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/LauncherActivity.java
@@ -3,6 +3,7 @@ package net.kdt.pojavlaunch;
 import static android.content.res.Configuration.ORIENTATION_PORTRAIT;
 import android.Manifest;
 import android.app.NotificationManager;
+import android.content.DialogInterface;
 import android.content.Context;
 import android.content.pm.PackageManager;
 import android.os.Build;
@@ -137,7 +138,6 @@ public class LauncherActivity extends BaseActivity {
             builder.setTitle("Error");
             builder.setMessage("Minecraft can't be legally installed when logged in with a local account. Please switch to an online account to continue.");
             builder.setPositiveButton("OK", new DialogInterface.OnClickListener() {
-                @Override
                 public void onClick(DialogInterface dialog, int which) {
                     dialog.dismiss();
                 }

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/LauncherActivity.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/LauncherActivity.java
@@ -133,24 +133,13 @@ public class LauncherActivity extends BaseActivity {
         }
         String normalizedVersionId = AsyncMinecraftDownloader.normalizeVersionId(prof.lastVersionId);
         JMinecraftVersionList.Version mcVersion = AsyncMinecraftDownloader.getListedVersion(normalizedVersionId);
-        if (mAccountSpinner.getSelectedAccount().isLocal()) {
-            AlertDialog.Builder builder = new AlertDialog.Builder(this);
-            builder.setTitle("Error");
-            builder.setMessage("Minecraft can't be legally installed when logged in with a local account. Please switch to an online account to continue.");
-            builder.setPositiveButton("OK", new DialogInterface.OnClickListener() {
-                public void onClick(DialogInterface dialog, int which) {
-                    dialog.dismiss();
-                }
-            });
-            AlertDialog dialog = builder.create();
-            dialog.show();
-            return false;
-        }
+        
         new MinecraftDownloader().start(
                 this,
                 mcVersion,
                 normalizedVersionId,
-                new ContextAwareDoneListener(this, normalizedVersionId)
+                new ContextAwareDoneListener(this, normalizedVersionId),
+                mAccountSpinner
         );
         return false;
     };

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/modloaders/OptiFineDownloadTask.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/modloaders/OptiFineDownloadTask.java
@@ -1,6 +1,9 @@
 package net.kdt.pojavlaunch.modloaders;
 
 import com.kdt.mcgui.ProgressLayout;
+import com.kdt.mcgui.mcAccountSpinner;
+
+import android.widget.Toast;
 
 import net.kdt.pojavlaunch.JMinecraftVersionList;
 import net.kdt.pojavlaunch.R;
@@ -9,6 +12,8 @@ import net.kdt.pojavlaunch.progresskeeper.ProgressKeeper;
 import net.kdt.pojavlaunch.tasks.AsyncMinecraftDownloader;
 import net.kdt.pojavlaunch.tasks.MinecraftDownloader;
 import net.kdt.pojavlaunch.utils.DownloadUtils;
+import net.kdt.pojavlaunch.extra.ExtraCore;
+import net.kdt.pojavlaunch.extra.ExtraConstants;
 
 import java.io.File;
 import java.io.IOException;
@@ -19,6 +24,7 @@ public class OptiFineDownloadTask implements Runnable, Tools.DownloaderFeedback,
     private static final Pattern sMcVersionPattern = Pattern.compile("([0-9]+)\\.([0-9]+)\\.?([0-9]+)?");
     private final OptiFineUtils.OptiFineVersion mOptiFineVersion;
     private final File mDestinationFile;
+    private mcAccountSpinner mAccountSpinner;
     private final ModloaderDownloadListener mListener;
     private final Object mMinecraftDownloadLock = new Object();
     private Throwable mDownloaderThrowable;
@@ -87,9 +93,13 @@ public class OptiFineDownloadTask implements Runnable, Tools.DownloaderFeedback,
         // the string is always normalized
         JMinecraftVersionList.Version minecraftJsonVersion = AsyncMinecraftDownloader.getListedVersion(minecraftVersion);
         if(minecraftJsonVersion == null) return false;
+        if(mAccountSpinner.getSelectedAccount() == null){
+            ExtraCore.setValue(ExtraConstants.SELECT_AUTH_METHOD, true);
+            return false;
+        }
         try {
             synchronized (mMinecraftDownloadLock) {
-                new MinecraftDownloader().start(null, minecraftJsonVersion, minecraftVersion, this);
+                new MinecraftDownloader().start(null, minecraftJsonVersion, minecraftVersion, this, mAccountSpinner);
                 mMinecraftDownloadLock.wait();
             }
         }catch (InterruptedException e) {

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/modloaders/OptiFineDownloadTask.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/modloaders/OptiFineDownloadTask.java
@@ -3,8 +3,6 @@ package net.kdt.pojavlaunch.modloaders;
 import com.kdt.mcgui.ProgressLayout;
 import com.kdt.mcgui.mcAccountSpinner;
 
-import android.widget.Toast;
-
 import net.kdt.pojavlaunch.JMinecraftVersionList;
 import net.kdt.pojavlaunch.R;
 import net.kdt.pojavlaunch.Tools;
@@ -12,8 +10,6 @@ import net.kdt.pojavlaunch.progresskeeper.ProgressKeeper;
 import net.kdt.pojavlaunch.tasks.AsyncMinecraftDownloader;
 import net.kdt.pojavlaunch.tasks.MinecraftDownloader;
 import net.kdt.pojavlaunch.utils.DownloadUtils;
-import net.kdt.pojavlaunch.extra.ExtraCore;
-import net.kdt.pojavlaunch.extra.ExtraConstants;
 
 import java.io.File;
 import java.io.IOException;
@@ -94,7 +90,6 @@ public class OptiFineDownloadTask implements Runnable, Tools.DownloaderFeedback,
         JMinecraftVersionList.Version minecraftJsonVersion = AsyncMinecraftDownloader.getListedVersion(minecraftVersion);
         if(minecraftJsonVersion == null) return false;
         if(mAccountSpinner.getSelectedAccount() == null){
-            ExtraCore.setValue(ExtraConstants.SELECT_AUTH_METHOD, true);
             return false;
         }
         try {

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/tasks/MinecraftDownloader.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/tasks/MinecraftDownloader.java
@@ -68,7 +68,6 @@ public class MinecraftDownloader {
                       @NonNull AsyncMinecraftDownloader.DoneListener listener,
                       @NonNull mcAccountSpinner minecraftAccount) {
         this.mcAccount = minecraftAccount;
-        this.mActivity = activity;
         sExecutorService.execute(() -> {
             try {
                 downloadGame(activity, version, realVersion);
@@ -251,7 +250,7 @@ public class MinecraftDownloader {
         FileUtils.ensureParentDirectory(targetFile);
         mDownloadFileCount++;
         mScheduledDownloadTasks.add(
-                new DownloaderTask(targetFile, downloadClass, url, sha1, size, skipIfFailed, mcAccount, mActivity)
+                new DownloaderTask(targetFile, downloadClass, url, sha1, size, skipIfFailed, mcAccount)
         );
     }
 
@@ -367,11 +366,9 @@ public class MinecraftDownloader {
         private int mLastCurr;
         private final long mDownloadSize;
         private mcAccountSpinner minecraftAccount;
-        private Activity mActivity;
-        public boolean failed;
 
         DownloaderTask(File targetPath, int downloadClass, String targetUrl, String targetSha1,
-                       long downloadSize, boolean skipIfFailed, mcAccountSpinner minecraftAccount, Activity activity) {
+                       long downloadSize, boolean skipIfFailed, mcAccountSpinner minecraftAccount) {
             this.mTargetPath = targetPath;
             this.mTargetUrl = targetUrl;
             this.mTargetSha1 = targetSha1;
@@ -379,8 +376,6 @@ public class MinecraftDownloader {
             this.mDownloadSize = downloadSize;
             this.mSkipIfFailed = skipIfFailed;
             this.minecraftAccount = minecraftAccount;
-            this.mActivity = activity;
-            this.failed = false;
         }
 
         @Override

--- a/app_pojavlauncher/src/main/res/values-en-rGB/strings.xml
+++ b/app_pojavlauncher/src/main/res/values-en-rGB/strings.xml
@@ -215,7 +215,7 @@
     <string name="main_add_account">Add account</string>
     <string name="tasks_ongoing">Tasks are in progress, please wait</string>
     <string name="no_saved_accounts">No saved accounts</string>
-    <string name="mc_download_failed">Failed to download Minecraft! This could be due to bad network connection, incorrectly placed files, etc..</string>
+    <string name="mc_download_failed">Failed to download Minecraft! This could be due to bad network connection, incorrectly placed files or you're trying to download Minecraft from a Local account.</string>
     <string name="xerr_unknown">Unknown Xbox Live API error %d</string>
     <string name="xerr_no_account">You don\'t seem to have an Xbox Live account. Please log in once on https://minecraft.net/ and try again.</string>
     <string name="xerr_adult_verification">An adult needs to verify your account.</string>

--- a/app_pojavlauncher/src/main/res/values/strings.xml
+++ b/app_pojavlauncher/src/main/res/values/strings.xml
@@ -250,7 +250,7 @@
     <string name="main_add_account">Add account</string>
     <string name="tasks_ongoing">Tasks are in progress, please wait</string>
     <string name="no_saved_accounts">No saved accounts</string>
-    <string name="mc_download_failed">Failed to download Minecraft! This could be due to bad network connection, incorrectly placed files, etc..</string>
+    <string name="mc_download_failed">Failed to download Minecraft! This could be due to bad network connection, incorrectly placed files or you're trying to download Minecraft from a Local account.</string>
     <string name="xerr_unknown">Unknown Xbox Live API error %d</string>
     <string name="xerr_no_account">You don\'t seem to have an Xbox Live account. Please log in once on https://minecraft.net/ and try again.</string>
     <string name="xerr_adult_verification">An adult needs to verify your account.</string>


### PR DESCRIPTION
This is related to https://github.com/PojavLauncherTeam/PojavLauncher/issues/4431, and I'm honestly quite shocked on how PoJav launcher for the longest time didn't fix this issue out, because it only took about 12 lines of code to fix this issue.

**Why is the Pull request necessary?** To comply with https://pojavlauncherteam.github.io/LOCAL-MODE.html, and to not face potential legal issues from Mojang.

Everything is tested and is verified to work.

TODO: Translation for other languages.