### PR TITLE
fix: dont remove task count listener until it reaches 0

### DIFF
--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/progresskeeper/ProgressKeeper.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/progresskeeper/ProgressKeeper.java
@@ -90,8 +90,8 @@ public class ProgressKeeper {
             public void onUpdateTaskCount(int taskCount) {
                 if(taskCount == 0) {
                     runnable.run();
+                    removeTaskCountListener(this);
                 }
-                removeTaskCountListener(this);
             }
         };
         addTaskCountListener(listener);


### PR DESCRIPTION
If waitUltilDone() is called when you have 2 or more other tasks, the first one that is changed will still have tasks to wait for, but when it finishes it won't run because it was removed early. 
(translated)