### PR TITLE
Check available addressable space before launching Java

### DIFF
--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/Architecture.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/Architecture.java
@@ -12,6 +12,22 @@ public class Architecture {
 	public static final int ARCH_X86 = 0x4;
 	public static final int ARCH_X86_64 = 0x8;
 
+	/* On both 32-bit ARM and x86, the top 1GB is reserved for kernel use. */
+	public static final long ADDRESS_SPACE_LIMIT_32_BIT = 0xbfffffffL;
+	/*
+	 * Technically, this is supposed to be 48 bits on x86_64, but nobody's allocating
+	 * 524288 terabytes of RAM on Pojav any time soon.
+	 */
+	public static final long ADDRESS_SPACE_LIMIT_64_BIT = 0x7fffffffffL;
+
+	/**
+	 * Get the highest byte accessible within the process's address space.
+	 * @return the highest byte accessible within the process's address space.
+	 */
+	public static long getAddressSpaceLimit() {
+		return is64BitsDevice() ? ADDRESS_SPACE_LIMIT_64_BIT : ADDRESS_SPACE_LIMIT_32_BIT;
+	}
+
 	/**
 	 * Tell us if the device supports 64 bits architecture
 	 * @return If the device supports 64 bits architecture

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/Tools.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/Tools.java
@@ -172,9 +172,9 @@ public final class Tools {
     public static void launchMinecraft(final AppCompatActivity activity, MinecraftAccount minecraftAccount,
                                        MinecraftProfile minecraftProfile, String versionId, int versionJavaRequirement) throws Throwable {
         int freeDeviceMemory = getFreeDeviceMemory(activity);
-        int freeAddressSpace = getMaxContinuousAddressSpaceSize();
         int localeString;
-        Log.i("MemStat", "Free RAM: "+freeDeviceMemory+" Addressable: "+freeAddressSpace);
+        int freeAddressSpace = Architecture.is32BitsDevice() ? getMaxContinuousAddressSpaceSize() : -1;
+        Log.i("MemStat", "Free RAM: " + freeDeviceMemory + " Addressable: " + freeAddressSpace);
         if(freeDeviceMemory > freeAddressSpace && freeAddressSpace != -1) {
             freeDeviceMemory = freeAddressSpace;
             localeString = R.string.address_memory_warning_msg;

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/Tools.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/Tools.java
@@ -172,7 +172,7 @@ public final class Tools {
     public static void launchMinecraft(final AppCompatActivity activity, MinecraftAccount minecraftAccount,
                                        MinecraftProfile minecraftProfile, String versionId, int versionJavaRequirement) throws Throwable {
         int freeDeviceMemory = getFreeDeviceMemory(activity);
-        int freeAddressSpace = getMaxContinousAddressSpaceSize();
+        int freeAddressSpace = getMaxContinuousAddressSpaceSize();
         int localeString;
         Log.i("MemStat", "Free RAM: "+freeDeviceMemory+" Addressable: "+freeAddressSpace);
         if(freeDeviceMemory > freeAddressSpace && freeAddressSpace != -1) {
@@ -936,7 +936,7 @@ public final class Tools {
         return (int) (memInfo.availMem / 1048576L);
     }
 
-    private static int getMaxContinuousAddressSpaceSize0() throws Exception{
+    private static int internalGetMaxContinuousAddressSpaceSize() throws Exception{
         MemoryHoleFinder memoryHoleFinder = new MemoryHoleFinder();
         new SelfMapsParser(memoryHoleFinder).run();
         long largestHole = memoryHoleFinder.getLargestHole();
@@ -944,9 +944,9 @@ public final class Tools {
         else return (int)(largestHole / 1048576L);
     }
 
-    public static int getMaxContinousAddressSpaceSize() {
+    public static int getMaxContinuousAddressSpaceSize() {
         try {
-            return getMaxContinuousAddressSpaceSize0();
+            return internalGetMaxContinuousAddressSpaceSize();
         }catch (Exception e){
             Log.w("Tools", "Failed to find the largest uninterrupted address space");
             return -1;

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/memory/MemoryHoleFinder.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/memory/MemoryHoleFinder.java
@@ -1,0 +1,22 @@
+package net.kdt.pojavlaunch.memory;
+
+import net.kdt.pojavlaunch.Architecture;
+
+public class MemoryHoleFinder implements SelfMapsParser.Callback {
+    private long mPreviousEnd = 0;
+    private long mLargestHole = -1;
+    private final long mAddressingLimit = Architecture.getAddressSpaceLimit();
+    @Override
+    public boolean process(long begin, long end, String wholeLine) {
+        if(begin >= mAddressingLimit) begin = mAddressingLimit;
+        long holeSize = begin - mPreviousEnd;
+        if(mLargestHole < holeSize) mLargestHole = holeSize;
+        if(begin == mAddressingLimit) return false;
+        mPreviousEnd = end;
+        return true;
+    }
+
+    public long getLargestHole() {
+        return mLargestHole;
+    }
+}

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/memory/SelfMapsParser.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/memory/SelfMapsParser.java
@@ -1,0 +1,35 @@
+package net.kdt.pojavlaunch.memory;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.Scanner;
+
+public class SelfMapsParser {
+    private final Callback mCallback;
+    public SelfMapsParser(Callback callback) {
+        mCallback = callback;
+    }
+
+    public void run() throws IOException, NumberFormatException {
+        try (FileInputStream fileInputStream = new FileInputStream("/proc/self/maps")) {
+            Scanner scanner = new Scanner(fileInputStream);
+            while(scanner.hasNextLine()) {
+                if(!forEachLine(scanner.nextLine())) break;
+            }
+        }
+    }
+
+    private boolean forEachLine(String line) throws NumberFormatException {
+        int firstSpaceIndex = line.indexOf(' ');
+        String addresses = line.substring(0, firstSpaceIndex);
+        String[] addressArray = addresses.split("-");
+        if(addressArray.length < 2) return true;
+        long begin = Long.parseLong(addressArray[0], 16);
+        long end = Long.parseLong(addressArray[1], 16);
+        return mCallback.process(begin, end, line);
+    }
+
+    public interface Callback {
+        boolean process(long startAddress, long endAddress, String wholeLine);
+    }
+}

--- a/app_pojavlauncher/src/main/res/values/strings.xml
+++ b/app_pojavlauncher/src/main/res/values/strings.xml
@@ -172,6 +172,7 @@
     <string name="customctrl_forward_lock">Forward lock</string>
     <string name="customctrl_absolute_tracking">Absolute finger tracking</string>
     <string name="memory_warning_msg">The current amount of free RAM (%d) is lower than allocated RAM (%d), which may lead to crashes. Change the allocation if the game crashes.</string>
+    <string name="address_memory_warning_msg">The current amount of free addressable RAM space (%d) is lower than the allocated RAM (%d), which will lead to crashes. Change the allocation if the game crashes.</string>
     <string name="mcl_memory_allocation">Memory allocation</string>
     <string name="mcl_memory_allocation_subtitle">Controls how much memory is given to Minecraft.</string>
     <string name="multirt_runtime_corrupt">Corrupted Java Runtime</string>


### PR DESCRIPTION
This allows the user to more precisely know how much RAM to allocate, especially on 32-bit devices which usually have less continuous address space available compared to the amount of free RAM.