### PR TITLE
Add a check for legitimate accounts

### DIFF
--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/LauncherActivity.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/LauncherActivity.java
@@ -24,6 +24,7 @@ import androidx.fragment.app.FragmentManager;
 import com.kdt.mcgui.ProgressLayout;
 import com.kdt.mcgui.mcAccountSpinner;
 
+import net.kdt.pojavlaunch.accounts.LocalAccountUtils;
 import net.kdt.pojavlaunch.contracts.OpenDocumentWithExtension;
 import net.kdt.pojavlaunch.extra.ExtraConstants;
 import net.kdt.pojavlaunch.extra.ExtraCore;
@@ -130,14 +131,26 @@ public class LauncherActivity extends BaseActivity {
             ExtraCore.setValue(ExtraConstants.SELECT_AUTH_METHOD, true);
             return false;
         }
-        String normalizedVersionId = AsyncMinecraftDownloader.normalizeVersionId(prof.lastVersionId);
-        JMinecraftVersionList.Version mcVersion = AsyncMinecraftDownloader.getListedVersion(normalizedVersionId);
-        new MinecraftDownloader().start(
-                this,
-                mcVersion,
-                normalizedVersionId,
-                new ContextAwareDoneListener(this, normalizedVersionId)
-        );
+
+        LocalAccountUtils.checkUsageAllowed(new LocalAccountUtils.CheckResultListener() {
+            @Override
+            public void onUsageAllowed() {
+                String normalizedVersionId = AsyncMinecraftDownloader.normalizeVersionId(prof.lastVersionId);
+                JMinecraftVersionList.Version mcVersion = AsyncMinecraftDownloader.getListedVersion(normalizedVersionId);
+                new MinecraftDownloader().start(
+                        LauncherActivity.this,
+                        mcVersion,
+                        normalizedVersionId,
+                        new ContextAwareDoneListener(LauncherActivity.this, normalizedVersionId)
+                );
+            }
+            @Override
+            public void onUsageDenied() {
+                LocalAccountUtils.openDialog(LauncherActivity.this,
+                        getString(R.string.no_microsoft_account) + "\r\n" + getString(R.string.purchase_minecraft_account_tip));
+            }
+        });
+
         return false;
     };
 

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/Tools.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/Tools.java
@@ -98,6 +98,7 @@ public final class Tools {
     public static final Gson GLOBAL_GSON = new GsonBuilder().setPrettyPrinting().create();
 
     public static final String URL_HOME = "https://pojavlauncherteam.github.io";
+    public static final String URL_MINECRAFT = "https://www.minecraft.net/";
     public static String NATIVE_LIB_DIR;
     public static String DIR_DATA; //Initialized later to get context
     public static File DIR_CACHE;

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/accounts/AccountsManager.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/accounts/AccountsManager.java
@@ -1,0 +1,69 @@
+package net.kdt.pojavlaunch.accounts;
+
+import android.util.Log;
+
+import net.kdt.pojavlaunch.Tools;
+import net.kdt.pojavlaunch.value.MinecraftAccount;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class AccountsManager {
+    private static final List<MinecraftAccount> accounts = new ArrayList<>();
+
+    public void reload() {
+        accounts.clear();
+        File accountsPath = new File(Tools.DIR_ACCOUNT_NEW);
+        if (accountsPath.exists() && accountsPath.isDirectory()) {
+            File[] files = accountsPath.listFiles();
+            if (files != null) {
+                for (File accountFile : files) {
+                    try {
+                        String jsonString = Tools.read(accountFile);
+                        MinecraftAccount account = MinecraftAccount.parse(jsonString);
+                        if (account != null) accounts.add(account);
+                    } catch (IOException e) {
+                        Log.e("AccountsManager", String.format("File %s is not recognized as a profile for an account", accountFile.getName()));
+                    }
+                }
+            }
+        }
+        Log.i("AccountsManager", "Reload complete.");
+    }
+
+    public void remove(String userName) {
+        if (userName == null) return;
+        for (MinecraftAccount account : accounts) {
+            if (account.username.equals(userName)) {
+                accounts.remove(account);
+                break;
+            }
+        }
+    }
+
+    public void add(MinecraftAccount account) {
+        if (account == null) return;
+        for (MinecraftAccount minecraftAccount : accounts) {
+            if (minecraftAccount.username.equals(account.username)) {
+                accounts.remove(minecraftAccount);
+                break;
+            }
+        }
+        accounts.add(account);
+    }
+
+    public static List<MinecraftAccount> getAllAccount() {
+        return new ArrayList<>(accounts);
+    }
+
+    public static boolean haveMicrosoftAccount() {
+        for (MinecraftAccount account : accounts) {
+            if (account.isMicrosoft) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/accounts/LocalAccountUtils.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/accounts/LocalAccountUtils.java
@@ -1,0 +1,30 @@
+package net.kdt.pojavlaunch.accounts;
+
+import android.app.Activity;
+import android.app.AlertDialog;
+
+import net.kdt.pojavlaunch.R;
+import net.kdt.pojavlaunch.Tools;
+
+public class LocalAccountUtils {
+    public static void checkUsageAllowed(CheckResultListener listener) {
+        if (AccountsManager.haveMicrosoftAccount()) {
+            listener.onUsageAllowed();
+        } else {
+            listener.onUsageDenied();
+        }
+    }
+
+    public static void openDialog(Activity activity, String message) {
+        new AlertDialog.Builder(activity)
+                .setMessage(message)
+                .setPositiveButton(R.string.global_yes, (dialogInterface, i) -> Tools.openURL(activity, Tools.URL_MINECRAFT))
+                .setNegativeButton(R.string.global_no, null)
+                .show();
+    }
+
+    public interface CheckResultListener {
+        void onUsageAllowed();
+        void onUsageDenied();
+    }
+}

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/fragments/SelectAuthFragment.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/fragments/SelectAuthFragment.java
@@ -7,9 +7,11 @@ import android.widget.Button;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentActivity;
 
 import net.kdt.pojavlaunch.R;
 import net.kdt.pojavlaunch.Tools;
+import net.kdt.pojavlaunch.accounts.LocalAccountUtils;
 
 public class SelectAuthFragment extends Fragment {
     public static final String TAG = "AUTH_SELECT_FRAGMENT";
@@ -23,7 +25,20 @@ public class SelectAuthFragment extends Fragment {
         Button mMicrosoftButton = view.findViewById(R.id.button_microsoft_authentication);
         Button mLocalButton = view.findViewById(R.id.button_local_authentication);
 
-        mMicrosoftButton.setOnClickListener(v -> Tools.swapFragment(requireActivity(), MicrosoftLoginFragment.class, MicrosoftLoginFragment.TAG, null));
-        mLocalButton.setOnClickListener(v -> Tools.swapFragment(requireActivity(), LocalLoginFragment.class, LocalLoginFragment.TAG, null));
+        FragmentActivity fragmentActivity = requireActivity();
+
+        mMicrosoftButton.setOnClickListener(v -> Tools.swapFragment(fragmentActivity, MicrosoftLoginFragment.class, MicrosoftLoginFragment.TAG, null));
+        mLocalButton.setOnClickListener(v -> LocalAccountUtils.checkUsageAllowed(new LocalAccountUtils.CheckResultListener() {
+            @Override
+            public void onUsageAllowed() {
+                Tools.swapFragment(fragmentActivity, LocalLoginFragment.class, LocalLoginFragment.TAG, null);
+            }
+
+            @Override
+            public void onUsageDenied() {
+                LocalAccountUtils.openDialog(fragmentActivity,
+                        getString(R.string.reject_local_account) + "\r\n" + getString(R.string.purchase_minecraft_account_tip));
+            }
+        }));
     }
 }

--- a/app_pojavlauncher/src/main/res/values/strings.xml
+++ b/app_pojavlauncher/src/main/res/values/strings.xml
@@ -257,6 +257,9 @@
     <string name="xerr_child">Your account is a child account, and needs to be added into a Family in order to log in.</string>
     <string name="minecraft_not_owned">It seems like this account does not have a Minecraft profile. If you have Xbox Game Pass, please log in on https://minecraft.net/ and set it up.</string>
     <string name="xerr_not_available">Xbox Live is not available in your country</string>
+    <string name="no_microsoft_account">Please log in with at least one official Minecraft account. We do not recommend launching Minecraft without a legitimate account.</string>
+    <string name="reject_local_account">It seems you are not logged in with an official account! The local account option is intended for players who cannot connect to the internet, not for those without a legitimate account.</string>
+    <string name="purchase_minecraft_account_tip">If you do not have a Minecraft official account, please purchase one from the official Minecraft website first!</string>
     <string name="preference_enable_gyro_title">Enable gyroscope controls</string>
     <string name="preference_enable_gyro_description">Enabling this will allow you to turn in-game by turning your phone.</string>
     <string name="preference_gyro_sensitivity_title">Gyroscope controls sensitivity</string>


### PR DESCRIPTION
I have added a simple account manager to check if a Microsoft account has been logged in. If the user has not logged in with a Microsoft account, logging into local accounts and starting the game will be prohibited. This is done to avoid potential legal issues.