### PR TITLE
Fix Snapdragon launch with 1.17+ forge loader crash on Zink renderer

### DIFF
--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/JREUtils.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/JREUtils.java
@@ -210,7 +210,6 @@ public class JREUtils {
         envMap.put("allow_higher_compat_version", "true");
         envMap.put("allow_glsl_extension_directive_midshader", "true");
         envMap.put("MESA_LOADER_DRIVER_OVERRIDE", "zink");
-        envMap.put("VTEST_SOCKET_NAME", new File(Tools.DIR_CACHE, ".virgl_test").getAbsolutePath());
 
         envMap.put("LD_LIBRARY_PATH", LD_LIBRARY_PATH);
         envMap.put("PATH", jreHome + "/bin:" + Os.getenv("PATH"));

--- a/app_pojavlauncher/src/main/jni/ctxbridges/osm_bridge.c
+++ b/app_pojavlauncher/src/main/jni/ctxbridges/osm_bridge.c
@@ -92,6 +92,7 @@ void osm_make_current(osm_render_window_t* bundle) {
         currentBundle = NULL;
         return;
     }
+    static bool hasSetNoRendererBuffer = false;
     bool hasSetMainWindow = false;
     currentBundle = bundle;
     if(pojav_environ->mainWindowBundle == NULL) {
@@ -105,7 +106,11 @@ void osm_make_current(osm_render_window_t* bundle) {
         osm_swap_surfaces(bundle);
         if(hasSetMainWindow) pojav_environ->mainWindowBundle->state = STATE_RENDERER_ALIVE;
     }
-    osm_set_no_render_buffer(&bundle->buffer);
+    if (!hasSetNoRendererBuffer)
+    {
+        osm_set_no_render_buffer(&bundle->buffer);
+        hasSetNoRendererBuffer = true;
+    }
     osm_apply_current_ll();
     OSMesaPixelStore_p(OSMESA_Y_UP,0);
 }

--- a/app_pojavlauncher/src/main/jni/ctxbridges/osm_bridge.c
+++ b/app_pojavlauncher/src/main/jni/ctxbridges/osm_bridge.c
@@ -11,6 +11,7 @@ static const char* g_LogTag = "GLBridge";
 static __thread osm_render_window_t* currentBundle;
 // a tiny buffer for rendering when there's nowhere t render
 static char no_render_buffer[4];
+static bool hasSetNoRendererBuffer = false;
 
 // Its not in a .h file because it is not supposed to be used outsife of this file.
 void setNativeWindowSwapInterval(struct ANativeWindow* nativeWindow, int swapInterval);
@@ -92,7 +93,6 @@ void osm_make_current(osm_render_window_t* bundle) {
         currentBundle = NULL;
         return;
     }
-    static bool hasSetNoRendererBuffer = false;
     bool hasSetMainWindow = false;
     currentBundle = bundle;
     if(pojav_environ->mainWindowBundle == NULL) {


### PR DESCRIPTION
When using 1.17 + forge loader, osm_make_current calls this buffer multiple times without rendering (osm_set_no_render_buffer),conflicts with the main rendering function, causing the image to not render correctly