### PR TITLE
Standardize URL User-Agent

### DIFF
--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/modloaders/modpacks/api/ApiHandler.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/modloaders/modpacks/api/ApiHandler.java
@@ -1,5 +1,7 @@
 package net.kdt.pojavlaunch.modloaders.modpacks.api;
 
+import static net.kdt.pojavlaunch.utils.DownloadUtils.USER_AGENT;
+
 import android.util.ArrayMap;
 import android.util.Log;
 
@@ -22,16 +24,15 @@ import java.util.Objects;
 @SuppressWarnings("unused")
 public class ApiHandler {
     public final String baseUrl;
-    public final Map<String, String> additionalHeaders;
+    public final Map<String, String> additionalHeaders = new ArrayMap<>();
 
     public ApiHandler(String url) {
         baseUrl = url;
-        additionalHeaders = null;
+        additionalHeaders.put("User-Agent", USER_AGENT);
     }
 
     public ApiHandler(String url, String apiKey) {
-        baseUrl = url;
-        additionalHeaders = new ArrayMap<>();
+        this(url);
         additionalHeaders.put("x-api-key", apiKey);
     }
 

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/DownloadUtils.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/DownloadUtils.java
@@ -14,7 +14,8 @@ import org.apache.commons.io.*;
 
 @SuppressWarnings("IOStreamConstructor")
 public class DownloadUtils {
-    public static final String USER_AGENT = Tools.APP_NAME;
+    //Standardize the User-Agent format to "Launcher Name/Launcher Version" to facilitate data collection by resource platforms.
+    public static final String USER_AGENT = Tools.APP_NAME + "/" + BuildConfig.VERSION_NAME;
 
     public static void download(String url, OutputStream os) throws IOException {
         download(new URL(url), os);
@@ -67,6 +68,7 @@ public class DownloadUtils {
         FileUtils.ensureParentDirectory(outputFile);
 
         HttpURLConnection conn = (HttpURLConnection) new URL(urlInput).openConnection();
+        conn.setRequestProperty("User-Agent", USER_AGENT);
         InputStream readStr = conn.getInputStream();
         try (FileOutputStream fos = new FileOutputStream(outputFile)) {
             int current;


### PR DESCRIPTION
Various resource-providing websites or game download mirror sources all need data statistics to understand which users or launchers are using their APIs. Standardizing the URL User-Agent for launchers will assist them in collecting this data.