### PR TITLE
Qol(settings): energy saving, simplified UI, better perf

### DIFF
--- a/app_pojavlauncher/src/main/java/com/kdt/CustomSeekbar.java
+++ b/app_pojavlauncher/src/main/java/com/kdt/CustomSeekbar.java
@@ -2,8 +2,13 @@ package com.kdt;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
+import android.content.res.TypedArray;
 import android.util.AttributeSet;
 import android.widget.SeekBar;
+
+import androidx.annotation.Nullable;
+
+import net.kdt.pojavlaunch.R;
 
 /**
  * Seekbar with ability to handle ranges and increments
@@ -19,22 +24,22 @@ public class CustomSeekbar extends SeekBar {
 
     public CustomSeekbar(Context context) {
         super(context);
-        setup();
+        setup(null);
     }
 
     public CustomSeekbar(Context context, AttributeSet attrs) {
         super(context, attrs);
-        setup();
+        setup(attrs);
     }
 
     public CustomSeekbar(Context context, AttributeSet attrs, int defStyleAttr) {
         super(context, attrs, defStyleAttr);
-        setup();
+        setup(attrs);
     }
 
     public CustomSeekbar(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
         super(context, attrs, defStyleAttr, defStyleRes);
-        setup();
+        setup(attrs);
     }
 
     public void setIncrement(int increment) {
@@ -75,7 +80,11 @@ public class CustomSeekbar extends SeekBar {
         mListener = l;
     }
 
-    public void setup() {
+    public void setup(@Nullable AttributeSet attrs) {
+        try (TypedArray attributes = getContext().obtainStyledAttributes(attrs, R.styleable.CustomSeekbar)) {
+            mIncrement = attributes.getInt(R.styleable.CustomSeekbar_seekBarIncrement, 1);
+        }
+
         super.setOnSeekBarChangeListener(new OnSeekBarChangeListener() {
             /** Store the previous progress to prevent double calls with increments */
             private int previousProgress = 0;

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MainActivity.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/MainActivity.java
@@ -243,8 +243,8 @@ public class MainActivity extends BaseActivity implements ControlButtonMenuListe
     @Override
     public void onAttachedToWindow() {
         // Post to get the correct display dimensions after layout.
+        LauncherPreferences.computeNotchSize(this);
         mControlLayout.post(()->{
-            LauncherPreferences.computeNotchSize(this);
             Tools.getDisplayMetrics(this);
             loadControls();
         });

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/Tools.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/Tools.java
@@ -513,33 +513,7 @@ public final class Tools {
         return displayMetrics;
     }
 
-    @SuppressWarnings("deprecation")
-    private static void setFullscreenLegacy(Activity activity, boolean fullscreen) {
-        final View decorView = activity.getWindow().getDecorView();
-        View.OnSystemUiVisibilityChangeListener visibilityChangeListener = visibility -> {
-            boolean multiWindowMode = SDK_INT >= 24 && activity.isInMultiWindowMode();
-            // When in multi-window mode, asking for fullscreen makes no sense (cause the launcher runs in a window)
-            // So, ignore the fullscreen setting when activity is in multi window mode
-            if(fullscreen && !multiWindowMode){
-                if ((visibility & View.SYSTEM_UI_FLAG_FULLSCREEN) == 0) {
-                    decorView.setSystemUiVisibility(View.SYSTEM_UI_FLAG_LAYOUT_STABLE
-                            | View.SYSTEM_UI_FLAG_FULLSCREEN
-                            | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
-                            | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
-                            | View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY
-                            | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN);
-                }
-            }else{
-                decorView.setSystemUiVisibility(View.SYSTEM_UI_FLAG_VISIBLE);
-            }
-
-        };
-        decorView.setOnSystemUiVisibilityChangeListener(visibilityChangeListener);
-        visibilityChangeListener.onSystemUiVisibilityChange(decorView.getSystemUiVisibility()); //call it once since the UI state may not change after the call, so the activity wont become fullscreen
-    }
-
-
-    private static void setFullscreenSdk30(Activity activity, boolean fullscreen) {
+    public static void setFullscreen(Activity activity, boolean fullscreen) {
         WindowInsetsControllerCompat windowInsetsController =
                 WindowCompat.getInsetsController(activity.getWindow(), activity.getWindow().getDecorView());
         if (windowInsetsController == null) {
@@ -571,15 +545,6 @@ public final class Tools {
                     return ViewCompat.onApplyWindowInsets(view, windowInsets);
                 });
 
-    }
-
-    public static void setFullscreen(Activity activity, boolean fullscreen) {
-        setFullscreenSdk30(activity, fullscreen);
-        /*
-        if (SDK_INT >= Build.VERSION_CODES.R) {
-        }else {
-            setFullscreenLegacy(activity, fullscreen);
-        }*/
     }
 
     public static DisplayMetrics currentDisplayMetrics;

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/Tools.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/Tools.java
@@ -1314,23 +1314,4 @@ public final class Tools {
                     }
                 }).show();
     }
-
-    public static void setThreadsPriority(int priority) {
-        Process.getThreadPriority(Process.myTid());
-
-
-
-        Map<Thread, StackTraceElement[]> threads = Thread.getAllStackTraces();
-        for (Thread thread : threads.keySet()) {
-            //Log.d("Tools, thread: ", thread.getName());
-            Log.d("Tools, thread: ", thread + " group: " + thread.getThreadGroup());
-            Log.d("Tools, thread: ", Arrays.toString(thread.getStackTrace()));
-            Log.d("Tools, thread: ", String.valueOf(thread.getState()));
-            try {
-                thread.setPriority(priority);
-            }catch (Exception e) {
-                Log.e("Tools: thread", "Failed to set priority", e);
-            }
-        }
-    }
 }

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/gamepad/Gamepad.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/gamepad/Gamepad.java
@@ -43,6 +43,7 @@ import static net.kdt.pojavlaunch.customcontrols.gamepad.GamepadJoystick.DIRECTI
 import static net.kdt.pojavlaunch.customcontrols.gamepad.GamepadJoystick.DIRECTION_WEST;
 import static net.kdt.pojavlaunch.customcontrols.gamepad.GamepadJoystick.isJoystickEvent;
 import static net.kdt.pojavlaunch.prefs.LauncherPreferences.PREF_DEADZONE_SCALE;
+import static net.kdt.pojavlaunch.prefs.LauncherPreferences.PREF_SCALE_FACTOR;
 import static net.kdt.pojavlaunch.utils.MCOptionUtils.getMcScale;
 import static org.lwjgl.glfw.CallbackBridge.sendKeyPress;
 import static org.lwjgl.glfw.CallbackBridge.sendMouseButton;
@@ -51,9 +52,6 @@ import fr.spse.gamepad_remapper.GamepadHandler;
 import fr.spse.gamepad_remapper.Settings;
 
 public class Gamepad implements GrabListener, GamepadHandler {
-
-    /* Resolution scaler option, allow downsizing a window */
-    private final float mScaleFactor = LauncherPreferences.DEFAULT_PREF.getInt("resolutionRatio",100)/100f;
 
     /* Sensitivity, adjusted according to screen size */
     private final double mSensitivityFactor = (1.4 * (1080f/ currentDisplayMetrics.heightPixels));
@@ -116,7 +114,7 @@ public class Gamepad implements GrabListener, GamepadHandler {
         mPointerImageView.setImageDrawable(ResourcesCompat.getDrawable(ctx.getResources(), R.drawable.ic_gamepad_pointer, ctx.getTheme()));
         mPointerImageView.getDrawable().setFilterBitmap(false);
 
-        int size = (int) ((22 * getMcScale()) / mScaleFactor);
+        int size = (int) ((22 * getMcScale()) / PREF_SCALE_FACTOR);
         mPointerImageView.setLayoutParams(new FrameLayout.LayoutParams(size, size));
 
         mMapProvider = mapProvider;
@@ -155,7 +153,7 @@ public class Gamepad implements GrabListener, GamepadHandler {
 
     public void notifyGUISizeChange(int newSize){
         //Change the pointer size to match UI
-        int size = (int) ((22 * newSize) / mScaleFactor);
+        int size = (int) ((22 * newSize) / PREF_SCALE_FACTOR);
         mPointerImageView.post(() -> mPointerImageView.setLayoutParams(new FrameLayout.LayoutParams(size, size)));
 
     }
@@ -228,7 +226,7 @@ public class Gamepad implements GrabListener, GamepadHandler {
             if(!isGrabbing){
                 CallbackBridge.mouseX = MathUtils.clamp(CallbackBridge.mouseX, 0, CallbackBridge.windowWidth);
                 CallbackBridge.mouseY = MathUtils.clamp(CallbackBridge.mouseY, 0, CallbackBridge.windowHeight);
-                placePointerView((int) (CallbackBridge.mouseX / mScaleFactor), (int) (CallbackBridge.mouseY/ mScaleFactor));
+                placePointerView((int) (CallbackBridge.mouseX / PREF_SCALE_FACTOR), (int) (CallbackBridge.mouseY/ PREF_SCALE_FACTOR));
             }
 
             //Send the mouse to the game
@@ -340,7 +338,7 @@ public class Gamepad implements GrabListener, GamepadHandler {
         placePointerView(CallbackBridge.physicalWidth/2, CallbackBridge.physicalHeight/2);
         mPointerImageView.setVisibility(View.VISIBLE);
         // Sensitivity in menu is MC and HARDWARE resolution dependent
-        mMouseSensitivity = 19 * mScaleFactor / mSensitivityFactor;
+        mMouseSensitivity = 19 * PREF_SCALE_FACTOR / mSensitivityFactor;
     }
 
     @Override

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/CustomSeekBarPreference.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/CustomSeekBarPreference.java
@@ -28,10 +28,10 @@ public class CustomSeekBarPreference extends SeekBarPreference {
     @SuppressLint("PrivateResource")
     public CustomSeekBarPreference(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
         super(context, attrs, defStyleAttr, defStyleRes);
-        TypedArray a = context.obtainStyledAttributes(
-                attrs, R.styleable.SeekBarPreference, defStyleAttr, defStyleRes);
-        mMin = a.getInt(R.styleable.SeekBarPreference_min, 0);
-        a.recycle();
+        try (TypedArray a = context.obtainStyledAttributes(
+                attrs, R.styleable.SeekBarPreference, defStyleAttr, defStyleRes)) {
+            mMin = a.getInt(R.styleable.SeekBarPreference_min, 0);
+        }
     }
 
     public CustomSeekBarPreference(Context context, AttributeSet attrs, int defStyleAttr) {

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/LauncherPreferences.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/LauncherPreferences.java
@@ -155,7 +155,7 @@ public class LauncherPreferences {
 
     /// Find a correct resolution for the device
     ///
-    /// Some devices are shipped with ridiculously high resolution, which can cause performance issues
+    /// Some devices are shipped with a ridiculously high resolution, which can cause performance issues
     /// This function will try to find a resolution that is good enough for the device
     private static int findBestResolution(Context context, boolean isDevicePowerful) {
         DisplayMetrics metrics = context.getResources().getDisplayMetrics();

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/LauncherPreferences.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/LauncherPreferences.java
@@ -17,6 +17,8 @@ import net.kdt.pojavlaunch.*;
 import net.kdt.pojavlaunch.multirt.MultiRTUtils;
 import net.kdt.pojavlaunch.utils.JREUtils;
 
+import java.io.IOException;
+
 public class LauncherPreferences {
     public static final String PREF_KEY_CURRENT_PROFILE = "currentProfile";
     public static final String PREF_KEY_SKIP_NOTIFICATION_CHECK = "skipNotificationPermissionCheck";
@@ -175,7 +177,20 @@ public class LauncherPreferences {
         DisplayMetrics metrics = context.getResources().getDisplayMetrics();
         if (Math.min(metrics.widthPixels, metrics.heightPixels) < 1080) return false;
         if (Runtime.getRuntime().availableProcessors() <= 4) return false;
+        if (hasAllCoreSameFreq()) return false;
         return true;
+    }
+
+    private static boolean hasAllCoreSameFreq() {
+        int coreCount = Runtime.getRuntime().availableProcessors();
+        try {
+            String freq0 = Tools.read("/sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq");
+            String freqX = Tools.read("/sys/devices/system/cpu/cpu" + (coreCount - 1) + "/cpufreq/cpuinfo_max_freq");
+            if(freq0.equals(freqX)) return true;
+        } catch (IOException e) {
+            Log.e("LauncherPreferences", "Failed to read CPU frequencies", e);
+        }
+        return false;
     }
 
     /** Compute the notch size to avoid being out of bounds */

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/QuickSettingSideDialog.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/QuickSettingSideDialog.java
@@ -123,7 +123,7 @@ public abstract class QuickSettingSideDialog extends com.kdt.SideDialogView {
         });
 
         mGyroSensitivityBar.setRange(25, 300);
-        mGyroSensitivityBar.setIncrement(5);
+        mGyroSensitivityBar.setIncrement(mGyroSensitivityBar.getContext().getResources().getInteger(R.integer.gyro_speed_seekbar_increment));
         mGyroSensitivityBar.setOnSeekBarChangeListener((SimpleSeekBarListener) (seekBar, progress, fromUser) -> {
             PREF_GYRO_SENSITIVITY = progress / 100f;
             mEditor.putInt("gyroSensitivity", progress);
@@ -133,7 +133,7 @@ public abstract class QuickSettingSideDialog extends com.kdt.SideDialogView {
         setSeekTextPercent(mGyroSensitivityText, mGyroSensitivityBar.getProgress());
 
         mMouseSpeedBar.setRange(25, 300);
-        mMouseSpeedBar.setIncrement(5);
+        mMouseSpeedBar.setIncrement(mMouseSpeedBar.getContext().getResources().getInteger(R.integer.mouse_speed_seekbar_increment));
         mMouseSpeedBar.setOnSeekBarChangeListener((SimpleSeekBarListener) (seekBar, progress, fromUser) -> {
             PREF_MOUSESPEED = progress / 100f;
             mEditor.putInt("mousespeed", progress);
@@ -143,7 +143,7 @@ public abstract class QuickSettingSideDialog extends com.kdt.SideDialogView {
         setSeekTextPercent(mMouseSpeedText, mMouseSpeedBar.getProgress());
 
         mGestureDelayBar.setRange(100, 1000);
-        mGestureDelayBar.setIncrement(10);
+        mGestureDelayBar.setIncrement(mGestureDelayBar.getContext().getResources().getInteger(R.integer.gesture_delay_seekbar_increment));
         mGestureDelayBar.setOnSeekBarChangeListener((SimpleSeekBarListener) (seekBar, progress, fromUser) -> {
             PREF_LONGPRESS_TRIGGER = progress;
             mEditor.putInt("timeLongPressTrigger", progress);
@@ -153,7 +153,7 @@ public abstract class QuickSettingSideDialog extends com.kdt.SideDialogView {
         setSeekTextMillisecond(mGestureDelayText, mGestureDelayBar.getProgress());
 
         mResolutionBar.setRange(25, 100);
-        mResolutionBar.setIncrement(5);
+        mResolutionBar.setIncrement(mResolutionBar.getContext().getResources().getInteger(R.integer.resolution_seekbar_increment));
         mResolutionBar.setOnSeekBarChangeListener((SimpleSeekBarListener) (seekBar, progress, fromUser) -> {
             PREF_SCALE_FACTOR = progress/100f;
             mEditor.putInt("resolutionRatio", progress);

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/QuickSettingSideDialog.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/QuickSettingSideDialog.java
@@ -122,7 +122,6 @@ public abstract class QuickSettingSideDialog extends com.kdt.SideDialogView {
             mEditor.putBoolean("disableGestures", isChecked);
         });
 
-        mGyroSensitivityBar.setRange(25, 300);
         mGyroSensitivityBar.setOnSeekBarChangeListener((SimpleSeekBarListener) (seekBar, progress, fromUser) -> {
             PREF_GYRO_SENSITIVITY = progress / 100f;
             mEditor.putInt("gyroSensitivity", progress);
@@ -131,7 +130,6 @@ public abstract class QuickSettingSideDialog extends com.kdt.SideDialogView {
         mGyroSensitivityBar.setProgress((int) (mOriginalGyroSensitivity * 100f));
         setSeekTextPercent(mGyroSensitivityText, mGyroSensitivityBar.getProgress());
 
-        mMouseSpeedBar.setRange(25, 300);
         mMouseSpeedBar.setOnSeekBarChangeListener((SimpleSeekBarListener) (seekBar, progress, fromUser) -> {
             PREF_MOUSESPEED = progress / 100f;
             mEditor.putInt("mousespeed", progress);
@@ -140,7 +138,6 @@ public abstract class QuickSettingSideDialog extends com.kdt.SideDialogView {
         mMouseSpeedBar.setProgress((int) (mOriginalMouseSpeed * 100f));
         setSeekTextPercent(mMouseSpeedText, mMouseSpeedBar.getProgress());
 
-        mGestureDelayBar.setRange(100, 1000);
         mGestureDelayBar.setOnSeekBarChangeListener((SimpleSeekBarListener) (seekBar, progress, fromUser) -> {
             PREF_LONGPRESS_TRIGGER = progress;
             mEditor.putInt("timeLongPressTrigger", progress);
@@ -149,7 +146,6 @@ public abstract class QuickSettingSideDialog extends com.kdt.SideDialogView {
         mGestureDelayBar.setProgress(mOriginalGestureDelay);
         setSeekTextMillisecond(mGestureDelayText, mGestureDelayBar.getProgress());
 
-        mResolutionBar.setRange(25, 100);
         mResolutionBar.setOnSeekBarChangeListener((SimpleSeekBarListener) (seekBar, progress, fromUser) -> {
             PREF_SCALE_FACTOR = progress/100f;
             mEditor.putInt("resolutionRatio", progress);

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/QuickSettingSideDialog.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/QuickSettingSideDialog.java
@@ -123,7 +123,6 @@ public abstract class QuickSettingSideDialog extends com.kdt.SideDialogView {
         });
 
         mGyroSensitivityBar.setRange(25, 300);
-        mGyroSensitivityBar.setIncrement(mGyroSensitivityBar.getContext().getResources().getInteger(R.integer.gyro_speed_seekbar_increment));
         mGyroSensitivityBar.setOnSeekBarChangeListener((SimpleSeekBarListener) (seekBar, progress, fromUser) -> {
             PREF_GYRO_SENSITIVITY = progress / 100f;
             mEditor.putInt("gyroSensitivity", progress);
@@ -133,7 +132,6 @@ public abstract class QuickSettingSideDialog extends com.kdt.SideDialogView {
         setSeekTextPercent(mGyroSensitivityText, mGyroSensitivityBar.getProgress());
 
         mMouseSpeedBar.setRange(25, 300);
-        mMouseSpeedBar.setIncrement(mMouseSpeedBar.getContext().getResources().getInteger(R.integer.mouse_speed_seekbar_increment));
         mMouseSpeedBar.setOnSeekBarChangeListener((SimpleSeekBarListener) (seekBar, progress, fromUser) -> {
             PREF_MOUSESPEED = progress / 100f;
             mEditor.putInt("mousespeed", progress);
@@ -143,7 +141,6 @@ public abstract class QuickSettingSideDialog extends com.kdt.SideDialogView {
         setSeekTextPercent(mMouseSpeedText, mMouseSpeedBar.getProgress());
 
         mGestureDelayBar.setRange(100, 1000);
-        mGestureDelayBar.setIncrement(mGestureDelayBar.getContext().getResources().getInteger(R.integer.gesture_delay_seekbar_increment));
         mGestureDelayBar.setOnSeekBarChangeListener((SimpleSeekBarListener) (seekBar, progress, fromUser) -> {
             PREF_LONGPRESS_TRIGGER = progress;
             mEditor.putInt("timeLongPressTrigger", progress);
@@ -153,7 +150,6 @@ public abstract class QuickSettingSideDialog extends com.kdt.SideDialogView {
         setSeekTextMillisecond(mGestureDelayText, mGestureDelayBar.getProgress());
 
         mResolutionBar.setRange(25, 100);
-        mResolutionBar.setIncrement(mResolutionBar.getContext().getResources().getInteger(R.integer.resolution_seekbar_increment));
         mResolutionBar.setOnSeekBarChangeListener((SimpleSeekBarListener) (seekBar, progress, fromUser) -> {
             PREF_SCALE_FACTOR = progress/100f;
             mEditor.putInt("resolutionRatio", progress);

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/screens/LauncherPreferenceControlFragment.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/screens/LauncherPreferenceControlFragment.java
@@ -32,31 +32,26 @@ public class LauncherPreferenceControlFragment extends LauncherPreferenceFragmen
 
         CustomSeekBarPreference seek2 = requirePreference("timeLongPressTrigger",
                 CustomSeekBarPreference.class);
-        seek2.setRange(100, 1000);
         seek2.setValue(longPressTrigger);
         seek2.setSuffix(" ms");
 
         CustomSeekBarPreference seek3 = requirePreference("buttonscale",
                 CustomSeekBarPreference.class);
-        seek3.setRange(80, 250);
         seek3.setValue(prefButtonSize);
         seek3.setSuffix(" %");
 
         CustomSeekBarPreference seek4 = requirePreference("mousescale",
                 CustomSeekBarPreference.class);
-        seek4.setRange(25, 300);
         seek4.setValue(mouseScale);
         seek4.setSuffix(" %");
 
         CustomSeekBarPreference seek6 = requirePreference("mousespeed",
                 CustomSeekBarPreference.class);
-        seek6.setRange(25, 300);
         seek6.setValue((int)(mouseSpeed *100f));
         seek6.setSuffix(" %");
 
         CustomSeekBarPreference deadzoneSeek = requirePreference("gamepad_deadzone_scale",
                 CustomSeekBarPreference.class);
-        deadzoneSeek.setRange(50, 200);
         deadzoneSeek.setValue((int) (joystickDeadzone * 100f));
         deadzoneSeek.setSuffix(" %");
 
@@ -71,13 +66,11 @@ public class LauncherPreferenceControlFragment extends LauncherPreferenceFragmen
 
         CustomSeekBarPreference gyroSensitivitySeek = requirePreference("gyroSensitivity",
                 CustomSeekBarPreference.class);
-        gyroSensitivitySeek.setRange(25, 300);
         gyroSensitivitySeek.setValue((int) (gyroSpeed*100f));
         gyroSensitivitySeek.setSuffix(" %");
 
         CustomSeekBarPreference gyroSampleRateSeek = requirePreference("gyroSampleRate",
                 CustomSeekBarPreference.class);
-        gyroSampleRateSeek.setRange(5, 50);
         gyroSampleRateSeek.setValue(gyroSampleRate);
         gyroSampleRateSeek.setSuffix(" ms");
         computeVisibility();

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/screens/LauncherPreferenceJavaFragment.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/screens/LauncherPreferenceJavaFragment.java
@@ -29,19 +29,18 @@ public class LauncherPreferenceJavaFragment extends LauncherPreferenceFragment {
         // Triggers a write for some reason
         addPreferencesFromResource(R.xml.pref_java);
 
-        CustomSeekBarPreference seek7 = requirePreference("allocation",
+        CustomSeekBarPreference memorySeekbar = requirePreference("allocation",
                 CustomSeekBarPreference.class);
 
         int maxRAM;
-        int deviceRam = getTotalDeviceMemory(seek7.getContext());
+        int deviceRam = getTotalDeviceMemory(memorySeekbar.getContext());
 
         if(is32BitsDevice() || deviceRam < 2048) maxRAM = Math.min(1024, deviceRam);
         else maxRAM = deviceRam - (deviceRam < 3064 ? 800 : 1024); //To have a minimum for the device to breathe
 
-        seek7.setMin(256);
-        seek7.setMax(maxRAM);
-        seek7.setValue(ramAllocation);
-        seek7.setSuffix(" MB");
+        memorySeekbar.setMax(maxRAM);
+        memorySeekbar.setValue(ramAllocation);
+        memorySeekbar.setSuffix(" MB");
 
         EditTextPreference editJVMArgs = findPreference("javaArgs");
         if (editJVMArgs != null) {

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/screens/LauncherPreferenceVideoFragment.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/screens/LauncherPreferenceVideoFragment.java
@@ -27,7 +27,6 @@ public class LauncherPreferenceVideoFragment extends LauncherPreferenceFragment 
 
         CustomSeekBarPreference resolutionSeekbar = requirePreference("resolutionRatio",
                 CustomSeekBarPreference.class);
-        resolutionSeekbar.setMin(25);
         resolutionSeekbar.setSuffix(" %");
 
         // #724 bug fix

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/screens/LauncherPreferenceVideoFragment.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/screens/LauncherPreferenceVideoFragment.java
@@ -1,7 +1,5 @@
 package net.kdt.pojavlaunch.prefs.screens;
 
-import static net.kdt.pojavlaunch.prefs.LauncherPreferences.PREF_NOTCH_SIZE;
-
 import android.content.SharedPreferences;
 import android.os.Build;
 import android.os.Bundle;
@@ -22,24 +20,31 @@ public class LauncherPreferenceVideoFragment extends LauncherPreferenceFragment 
     @Override
     public void onCreatePreferences(Bundle b, String str) {
         addPreferencesFromResource(R.xml.pref_video);
+        int resolution = (int) (LauncherPreferences.PREF_SCALE_FACTOR * 100);
 
         //Disable notch checking behavior on android 8.1 and below.
-        requirePreference("ignoreNotch").setVisible(Build.VERSION.SDK_INT >= Build.VERSION_CODES.P && PREF_NOTCH_SIZE > 0);
+        requirePreference("ignoreNotch").setVisible(Build.VERSION.SDK_INT >= Build.VERSION_CODES.P && LauncherPreferences.PREF_NOTCH_SIZE > 0);
 
-        CustomSeekBarPreference seek5 = requirePreference("resolutionRatio",
+        CustomSeekBarPreference resolutionSeekbar = requirePreference("resolutionRatio",
                 CustomSeekBarPreference.class);
-        seek5.setMin(25);
-        seek5.setSuffix(" %");
+        resolutionSeekbar.setMin(25);
+        resolutionSeekbar.setSuffix(" %");
 
         // #724 bug fix
-        if (seek5.getValue() < 25) {
-            seek5.setValue(100);
+        if (resolution < 25) {
+            resolutionSeekbar.setValue(100);
+        } else {
+            resolutionSeekbar.setValue(resolution);
         }
 
         // Sustained performance is only available since Nougat
         SwitchPreference sustainedPerfSwitch = requirePreference("sustainedPerformance",
                 SwitchPreference.class);
         sustainedPerfSwitch.setVisible(Build.VERSION.SDK_INT >= Build.VERSION_CODES.N);
+        sustainedPerfSwitch.setChecked(LauncherPreferences.PREF_SUSTAINED_PERFORMANCE);
+
+        requirePreference("alternate_surface", SwitchPreferenceCompat.class).setChecked(LauncherPreferences.PREF_USE_ALTERNATE_SURFACE);
+        requirePreference("force_vsync", SwitchPreferenceCompat.class).setChecked(LauncherPreferences.PREF_FORCE_VSYNC);
 
         ListPreference rendererListPreference = requirePreference("renderer",
                 ListPreference.class);

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/profiles/ProfileAdapter.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/profiles/ProfileAdapter.java
@@ -95,21 +95,21 @@ public class ProfileAdapter extends BaseAdapter {
         Drawable cachedIcon = ProfileIconCache.fetchIcon(v.getResources(), nm, minecraftProfile.icon);
         extendedTextView.setCompoundDrawablesRelative(cachedIcon, null, extendedTextView.getCompoundsDrawables()[2], null);
 
-        if(Tools.isValidString(minecraftProfile.name))
-            extendedTextView.setText(minecraftProfile.name);
-        else
-            extendedTextView.setText(R.string.unnamed);
+        // Historically, the profile name "New" was hardcoded as the default profile name
+        // We consider "New" the same as putting no name at all
+        String profileName = (Tools.isValidString(minecraftProfile.name) && !"New".equalsIgnoreCase(minecraftProfile.name)) ? minecraftProfile.name : null;
+        String versionName = minecraftProfile.lastVersionId;
 
-        if(minecraftProfile.lastVersionId != null){
-            if(minecraftProfile.lastVersionId.equalsIgnoreCase("latest-release")){
-                extendedTextView.setText( String.format("%s - %s", extendedTextView.getText(), v.getContext().getText(R.string.profiles_latest_release)));
-            } else if(minecraftProfile.lastVersionId.equalsIgnoreCase("latest-snapshot")){
-                extendedTextView.setText( String.format("%s - %s", extendedTextView.getText(), v.getContext().getText(R.string.profiles_latest_snapshot)));
-            } else {
-                extendedTextView.setText( String.format("%s - %s", extendedTextView.getText(), minecraftProfile.lastVersionId));
-            }
+        if (MinecraftProfile.LATEST_RELEASE.equalsIgnoreCase(versionName))
+            versionName = v.getContext().getString(R.string.profiles_latest_release);
+        else if (MinecraftProfile.LATEST_SNAPSHOT.equalsIgnoreCase(versionName))
+            versionName = v.getContext().getString(R.string.profiles_latest_snapshot);
 
-        } else extendedTextView.setText(extendedTextView.getText());
+        if (versionName == null && profileName != null)
+            extendedTextView.setText(profileName);
+        else if (versionName != null && profileName == null)
+            extendedTextView.setText(versionName);
+        else extendedTextView.setText(String.format("%s - %s", profileName, versionName));
 
         // Set selected background if needed
         if(displaySelection){

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/tasks/AsyncMinecraftDownloader.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/tasks/AsyncMinecraftDownloader.java
@@ -3,13 +3,14 @@ package net.kdt.pojavlaunch.tasks;
 import net.kdt.pojavlaunch.JMinecraftVersionList;
 import net.kdt.pojavlaunch.extra.ExtraConstants;
 import net.kdt.pojavlaunch.extra.ExtraCore;
+import net.kdt.pojavlaunch.value.launcherprofiles.MinecraftProfile;
 
 public class AsyncMinecraftDownloader {
     public static String normalizeVersionId(String versionString) {
         JMinecraftVersionList versionList = (JMinecraftVersionList) ExtraCore.getValue(ExtraConstants.RELEASE_TABLE);
         if(versionList == null || versionList.versions == null) return versionString;
-        if("latest-release".equals(versionString)) versionString = versionList.latest.get("release");
-        if("latest-snapshot".equals(versionString)) versionString = versionList.latest.get("snapshot");
+        if(MinecraftProfile.LATEST_RELEASE.equals(versionString)) versionString = versionList.latest.get("release");
+        if(MinecraftProfile.LATEST_SNAPSHOT.equals(versionString)) versionString = versionList.latest.get("snapshot");
         return versionString;
     }
 

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/JREUtils.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/JREUtils.java
@@ -295,6 +295,8 @@ public class JREUtils {
         purgeArg(userArgs, "-Dorg.lwjgl.opengl.libname");
         // Don't let the user specify a custom Freetype library (as the user is unlikely to specify a version compiled for Android)
         purgeArg(userArgs, "-Dorg.lwjgl.freetype.libname");
+        // Overridden by us to specify the exact number of cores that the android system has
+        purgeArg(userArgs, "-XX:ActiveProcessorCount");
 
         //Add automatically generated args
         userArgs.add("-Xms" + LauncherPreferences.PREF_RAM_ALLOCATION + "M");
@@ -304,6 +306,9 @@ public class JREUtils {
         // Force LWJGL to use the Freetype library intended for it, instead of using the one
         // that we ship with Java (since it may be older than what's needed)
         userArgs.add("-Dorg.lwjgl.freetype.libname="+ NATIVE_LIB_DIR+"/libfreetype.so");
+
+        // Some phones are not using the right number of cores, fix that
+        userArgs.add("-XX:ActiveProcessorCount=" + java.lang.Runtime.getRuntime().availableProcessors());
 
         userArgs.addAll(JVMArgs);
         activity.runOnUiThread(() -> Toast.makeText(activity, activity.getString(R.string.autoram_info_msg,LauncherPreferences.PREF_RAM_ALLOCATION), Toast.LENGTH_SHORT).show());

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/LocaleUtils.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/LocaleUtils.java
@@ -2,6 +2,7 @@ package net.kdt.pojavlaunch.utils;
 
 
 import static net.kdt.pojavlaunch.prefs.LauncherPreferences.DEFAULT_PREF;
+import static net.kdt.pojavlaunch.prefs.LauncherPreferences.PREF_FORCE_ENGLISH;
 
 import android.content.*;
 import android.content.res.*;
@@ -24,7 +25,7 @@ public class LocaleUtils extends ContextWrapper {
             LauncherPreferences.loadPreferences(context);
         }
 
-        if(DEFAULT_PREF.getBoolean("force_english", false)){
+        if(PREF_FORCE_ENGLISH){
             Resources resources = context.getResources();
             Configuration configuration = resources.getConfiguration();
 

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/value/launcherprofiles/MinecraftProfile.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/value/launcherprofiles/MinecraftProfile.java
@@ -5,6 +5,9 @@ import androidx.annotation.Keep;
 @Keep
 public class MinecraftProfile {
 
+	public static String LATEST_RELEASE = "latest-release";
+	public static String LATEST_SNAPSHOT= "latest-snapshot";
+
 	public String name;
 	public String type;
 	public String created;
@@ -23,8 +26,8 @@ public class MinecraftProfile {
 
 	public static MinecraftProfile createTemplate(){
 		MinecraftProfile TEMPLATE = new MinecraftProfile();
-		TEMPLATE.name = "New";
-		TEMPLATE.lastVersionId = "latest-release";
+		TEMPLATE.name = "";
+		TEMPLATE.lastVersionId = LATEST_RELEASE;
 		return TEMPLATE;
 	}
 

--- a/app_pojavlauncher/src/main/res/layout/dialog_quick_setting.xml
+++ b/app_pojavlauncher/src/main/res/layout/dialog_quick_setting.xml
@@ -26,7 +26,7 @@
         android:id="@+id/editResolution_seekbar"
         android:layout_width="0dp"
         android:layout_height="@dimen/_36sdp"
-
+        android:min="@integer/resolution_seekbar_min"
         app:seekBarIncrement="@integer/resolution_seekbar_increment"
 
         app:layout_constraintEnd_toEndOf="parent"
@@ -36,9 +36,9 @@
 
     <TextView
         android:id="@+id/editResolution_textView_percent"
-        android:layout_width="50dp"
+        android:layout_width="150dp"
         android:layout_height="0dp"
-        android:gravity="center"
+        android:gravity="end"
         tools:text="50%"
 
         app:layout_constraintBottom_toBottomOf="@id/editResolution_textView"
@@ -94,6 +94,8 @@
         android:layout_width="0dp"
         android:layout_height="@dimen/_36sdp"
 
+        android:min="@integer/gyro_speed_seekbar_min"
+        android:max="@integer/gyro_speed_seekbar_max"
         app:seekBarIncrement="@integer/gyro_speed_seekbar_increment"
 
         app:layout_constraintEnd_toEndOf="parent"
@@ -103,9 +105,9 @@
 
     <TextView
         android:id="@+id/editGyro_textView_percent"
-        android:layout_width="50dp"
+        android:layout_width="150dp"
         android:layout_height="0dp"
-        android:gravity="center"
+        android:gravity="end"
         tools:text="100%"
 
         app:layout_constraintBottom_toBottomOf="@id/editGyro_textView"
@@ -131,6 +133,8 @@
         android:layout_width="0dp"
         android:layout_height="@dimen/_36sdp"
 
+        android:min="@integer/mouse_speed_seekbar_min"
+        android:max="@integer/mouse_speed_seekbar_max"
         app:seekBarIncrement="@integer/mouse_speed_seekbar_increment"
 
         app:layout_constraintEnd_toEndOf="parent"
@@ -140,9 +144,9 @@
 
     <TextView
         android:id="@+id/editMouseSpeed_textView_percent"
-        android:layout_width="50dp"
+        android:layout_width="150dp"
         android:layout_height="0dp"
-        android:gravity="center"
+        android:gravity="end"
         tools:text="100%"
 
         app:layout_constraintBottom_toBottomOf="@id/editMouseSpeed_textView"
@@ -178,6 +182,8 @@
         android:layout_width="0dp"
         android:layout_height="@dimen/_36sdp"
 
+        android:min="@integer/gesture_delay_seekbar_min"
+        android:max="@integer/gesture_delay_seekbar_max"
         app:seekBarIncrement="@integer/gesture_delay_seekbar_increment"
 
         app:layout_constraintEnd_toEndOf="parent"
@@ -187,10 +193,10 @@
 
     <TextView
         android:id="@+id/editGestureDelay_textView_percent"
-        android:layout_width="50dp"
+        android:layout_width="150dp"
         android:layout_height="0dp"
-        android:gravity="center"
-        tools:text="270ms"
+        android:gravity="end"
+        tools:text="270 ms"
 
         app:layout_constraintBottom_toBottomOf="@id/editGestureDelay_textView"
         app:layout_constraintEnd_toEndOf="parent"

--- a/app_pojavlauncher/src/main/res/layout/dialog_quick_setting.xml
+++ b/app_pojavlauncher/src/main/res/layout/dialog_quick_setting.xml
@@ -27,6 +27,8 @@
         android:layout_width="0dp"
         android:layout_height="@dimen/_36sdp"
 
+        app:seekBarIncrement="@integer/resolution_seekbar_increment"
+
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.538"
         app:layout_constraintStart_toStartOf="parent"
@@ -92,6 +94,8 @@
         android:layout_width="0dp"
         android:layout_height="@dimen/_36sdp"
 
+        app:seekBarIncrement="@integer/gyro_speed_seekbar_increment"
+
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.538"
         app:layout_constraintStart_toStartOf="parent"
@@ -126,6 +130,8 @@
         android:id="@+id/editMouseSpeed_seekbar"
         android:layout_width="0dp"
         android:layout_height="@dimen/_36sdp"
+
+        app:seekBarIncrement="@integer/mouse_speed_seekbar_increment"
 
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.538"
@@ -171,6 +177,8 @@
         android:id="@+id/editGestureDelay_seekbar"
         android:layout_width="0dp"
         android:layout_height="@dimen/_36sdp"
+
+        app:seekBarIncrement="@integer/gesture_delay_seekbar_increment"
 
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.538"

--- a/app_pojavlauncher/src/main/res/values/attributes.xml
+++ b/app_pojavlauncher/src/main/res/values/attributes.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <attr name="seekBarIncrement" format="integer" />
+    <declare-styleable name="CustomSeekbar">
+        <attr name="seekBarIncrement" />
+    </declare-styleable>
+</resources>

--- a/app_pojavlauncher/src/main/res/values/attributes.xml
+++ b/app_pojavlauncher/src/main/res/values/attributes.xml
@@ -3,5 +3,7 @@
     <attr name="seekBarIncrement" format="integer" />
     <declare-styleable name="CustomSeekbar">
         <attr name="seekBarIncrement" />
+        <!-- Redefine to be able to fetch the value -->
+        <attr name="android:min" />
     </declare-styleable>
 </resources>

--- a/app_pojavlauncher/src/main/res/values/values.xml
+++ b/app_pojavlauncher/src/main/res/values/values.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <integer name="resolution_seekbar_increment">5</integer>
+    <integer name="gesture_delay_seekbar_increment">10</integer>
+    <integer name="button_scale_seekbar_increment">5</integer>
+    <integer name="mouse_scale_seekbar_increment">5</integer>
+    <integer name="mouse_speed_seekbar_increment">5</integer>
+    <integer name="gyro_speed_seekbar_increment">5</integer>
+    <integer name="gamepad_deadzone_seekbar_increment">5</integer>
+    <integer name="memory_seekbar_increment">8</integer>
+</resources>

--- a/app_pojavlauncher/src/main/res/values/values.xml
+++ b/app_pojavlauncher/src/main/res/values/values.xml
@@ -1,11 +1,37 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <integer name="resolution_seekbar_increment">5</integer>
+    <integer name="resolution_seekbar_min">25</integer>
+
     <integer name="gesture_delay_seekbar_increment">10</integer>
+    <integer name="gesture_delay_seekbar_min">100</integer>
+    <integer name="gesture_delay_seekbar_max">1000</integer>
+
+
     <integer name="button_scale_seekbar_increment">5</integer>
+    <integer name="button_scale_seekbar_min">80</integer>
+    <integer name="button_scale_seekbar_max">250</integer>
+
     <integer name="mouse_scale_seekbar_increment">5</integer>
+    <integer name="mouse_scale_seekbar_min">25</integer>
+    <integer name="mouse_scale_seekbar_max">300</integer>
+
     <integer name="mouse_speed_seekbar_increment">5</integer>
+    <integer name="mouse_speed_seekbar_min">25</integer>
+    <integer name="mouse_speed_seekbar_max">300</integer>
+
     <integer name="gyro_speed_seekbar_increment">5</integer>
+    <integer name="gyro_speed_seekbar_min">25</integer>
+    <integer name="gyro_speed_seekbar_max">300</integer>
+
+    <integer name="gyro_rate_seekbar_min">5</integer>
+    <integer name="gyro_rate_seekbar_max">50</integer>
+
     <integer name="gamepad_deadzone_seekbar_increment">5</integer>
+    <integer name="gamepad_deadzone_seekbar_min">50</integer>
+    <integer name="gamepad_deadzone_seekbar_max">200</integer>
+
     <integer name="memory_seekbar_increment">8</integer>
+    <integer name="memory_seekbar_min">256</integer>
+
 </resources>

--- a/app_pojavlauncher/src/main/res/xml/pref_control.xml
+++ b/app_pojavlauncher/src/main/res/xml/pref_control.xml
@@ -35,7 +35,7 @@
             android:title="@string/mcl_setting_title_longpresstrigger"
             app2:showSeekBarValue="true"
             app2:selectable="false"
-            app2:seekBarIncrement="10"
+            app2:seekBarIncrement="@integer/gesture_delay_seekbar_increment"
             android:icon="@drawable/ic_setting_gesture_time"
             />
 
@@ -50,7 +50,7 @@
             android:summary="@string/mcl_setting_subtitle_buttonscale"
             app2:showSeekBarValue="true"
             app2:selectable="false"
-            app2:seekBarIncrement="5"
+            app2:seekBarIncrement="@integer/button_scale_seekbar_increment"
             android:icon="@drawable/ic_setting_control_scale"
             />
         <SwitchPreference
@@ -71,7 +71,7 @@
             android:title="@string/mcl_setting_title_mousescale"
 
             app2:selectable="false"
-            app2:seekBarIncrement="5"
+            app2:seekBarIncrement="@integer/mouse_scale_seekbar_increment"
             app2:showSeekBarValue="true"
             android:icon="@drawable/ic_setting_pointer_scale"
             />
@@ -82,7 +82,7 @@
             android:title="@string/mcl_setting_title_mousespeed"
             android:icon="@drawable/ic_setting_mouse_speed"
             app2:selectable="false"
-            app2:seekBarIncrement="5"
+            app2:seekBarIncrement="@integer/mouse_speed_seekbar_increment"
             app2:showSeekBarValue="true" />
         <SwitchPreference
             android:key="mouse_start"
@@ -104,7 +104,7 @@
             android:title="@string/preference_gyro_sensitivity_title"
             android:summary="@string/preference_gyro_sensitivity_description"
             app2:selectable="false"
-            app2:seekBarIncrement="5"
+            app2:seekBarIncrement="@integer/gyro_speed_seekbar_increment"
             app2:showSeekBarValue="true"/>
         <net.kdt.pojavlaunch.prefs.CustomSeekBarPreference
             android:key="gyroSampleRate"
@@ -145,7 +145,7 @@
             android:title="@string/preference_deadzone_scale_title"
             android:summary="@string/preference_deadzone_scale_description"
             app2:showSeekBarValue="true"
-            app2:seekBarIncrement="5"
+            app2:seekBarIncrement="@integer/gamepad_deadzone_seekbar_increment"
             />
 
     </PreferenceCategory>

--- a/app_pojavlauncher/src/main/res/xml/pref_control.xml
+++ b/app_pojavlauncher/src/main/res/xml/pref_control.xml
@@ -35,6 +35,8 @@
             android:title="@string/mcl_setting_title_longpresstrigger"
             app2:showSeekBarValue="true"
             app2:selectable="false"
+            app2:min="@integer/gesture_delay_seekbar_min"
+            android:max="@integer/gesture_delay_seekbar_max"
             app2:seekBarIncrement="@integer/gesture_delay_seekbar_increment"
             android:icon="@drawable/ic_setting_gesture_time"
             />
@@ -50,6 +52,8 @@
             android:summary="@string/mcl_setting_subtitle_buttonscale"
             app2:showSeekBarValue="true"
             app2:selectable="false"
+            app2:min="@integer/button_scale_seekbar_min"
+            android:max="@integer/button_scale_seekbar_max"
             app2:seekBarIncrement="@integer/button_scale_seekbar_increment"
             android:icon="@drawable/ic_setting_control_scale"
             />
@@ -71,6 +75,8 @@
             android:title="@string/mcl_setting_title_mousescale"
 
             app2:selectable="false"
+            app2:min="@integer/mouse_scale_seekbar_min"
+            android:max="@integer/mouse_scale_seekbar_max"
             app2:seekBarIncrement="@integer/mouse_scale_seekbar_increment"
             app2:showSeekBarValue="true"
             android:icon="@drawable/ic_setting_pointer_scale"
@@ -82,6 +88,8 @@
             android:title="@string/mcl_setting_title_mousespeed"
             android:icon="@drawable/ic_setting_mouse_speed"
             app2:selectable="false"
+            app2:min="@integer/mouse_speed_seekbar_min"
+            android:max="@integer/mouse_speed_seekbar_max"
             app2:seekBarIncrement="@integer/mouse_speed_seekbar_increment"
             app2:showSeekBarValue="true" />
         <SwitchPreference
@@ -104,12 +112,16 @@
             android:title="@string/preference_gyro_sensitivity_title"
             android:summary="@string/preference_gyro_sensitivity_description"
             app2:selectable="false"
+            app2:min="@integer/gyro_speed_seekbar_min"
+            android:max="@integer/gyro_speed_seekbar_max"
             app2:seekBarIncrement="@integer/gyro_speed_seekbar_increment"
             app2:showSeekBarValue="true"/>
         <net.kdt.pojavlaunch.prefs.CustomSeekBarPreference
             android:key="gyroSampleRate"
             android:title="@string/preference_gyro_sample_rate_title"
             android:summary="@string/preference_gyro_sample_rate_description"
+            app2:min="@integer/gyro_rate_seekbar_min"
+            android:max="@integer/gyro_rate_seekbar_max"
             app2:selectable="false"
             app2:showSeekBarValue="true"/>
         <SwitchPreferenceCompat
@@ -145,6 +157,8 @@
             android:title="@string/preference_deadzone_scale_title"
             android:summary="@string/preference_deadzone_scale_description"
             app2:showSeekBarValue="true"
+            app2:min="@integer/gamepad_deadzone_seekbar_min"
+            android:max="@integer/gamepad_deadzone_seekbar_max"
             app2:seekBarIncrement="@integer/gamepad_deadzone_seekbar_increment"
             />
 

--- a/app_pojavlauncher/src/main/res/xml/pref_java.xml
+++ b/app_pojavlauncher/src/main/res/xml/pref_java.xml
@@ -25,7 +25,7 @@
             android:summary="@string/mcl_memory_allocation_subtitle"
             android:title="@string/mcl_memory_allocation"
             app2:showSeekBarValue="true"
-            app2:seekBarIncrement="8"
+            app2:seekBarIncrement="@integer/memory_seekbar_increment"
             app2:selectable="false"/>
 
         <SwitchPreference

--- a/app_pojavlauncher/src/main/res/xml/pref_java.xml
+++ b/app_pojavlauncher/src/main/res/xml/pref_java.xml
@@ -25,6 +25,7 @@
             android:summary="@string/mcl_memory_allocation_subtitle"
             android:title="@string/mcl_memory_allocation"
             app2:showSeekBarValue="true"
+            app2:min="@integer/memory_seekbar_min"
             app2:seekBarIncrement="@integer/memory_seekbar_increment"
             app2:selectable="false"/>
 

--- a/app_pojavlauncher/src/main/res/xml/pref_video.xml
+++ b/app_pojavlauncher/src/main/res/xml/pref_video.xml
@@ -26,6 +26,7 @@
             android:title="@string/mcl_setting_title_resolution_scaler"
             app2:showSeekBarValue="true"
             app2:selectable="false"
+            app2:min="@integer/resolution_seekbar_min"
             app2:seekBarIncrement="@integer/resolution_seekbar_increment"
             android:icon="@drawable/ic_setting_screen_resolution"
             />

--- a/app_pojavlauncher/src/main/res/xml/pref_video.xml
+++ b/app_pojavlauncher/src/main/res/xml/pref_video.xml
@@ -26,7 +26,7 @@
             android:title="@string/mcl_setting_title_resolution_scaler"
             app2:showSeekBarValue="true"
             app2:selectable="false"
-            app2:seekBarIncrement="5"
+            app2:seekBarIncrement="@integer/resolution_seekbar_increment"
             android:icon="@drawable/ic_setting_screen_resolution"
             />
 


### PR DESCRIPTION
# Why does this PR exist ?
This PR aims to make the user experience slightly better:
- It brings a new set of default settings to take into account more (and less) powerful devices.
- It changes a few UI elements to allow the user to focus on the action he wants the most

## Notable changes
### Changes in behavior
- Resolution, ASR, vsync and sustained performance is tweaked depending on whether a device is considered "powerful"
- The profile selector will now display a simplified profile name if no name is provided. No name is present by default for new profiles
- A new JVM argument is now under control of the launcher. It allows to properly state the amount of cores present on the device, increasing performance slightly.

### Refactors
- seekbar increments (among other resources) have been centralised into a resource file and turned into XML settings for their respective views
- some strings have been de-duplicated

### Fixes
- The gamepad is now able of the resolution changing on the fly
- (Android <= Q) The notch size was not computed properly in game