### PR TITLE
Fix the issue where the long-press trigger delay does not refresh properly.

### DIFF
--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/mouse/LeftClickGesture.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/mouse/LeftClickGesture.java
@@ -17,7 +17,7 @@ public class LeftClickGesture extends ValidatorGesture {
     private boolean mMouseActivated;
 
     public LeftClickGesture(Handler handler) {
-        super(handler, LauncherPreferences.PREF_LONGPRESS_TRIGGER);
+        super(handler);
     }
 
     public final void inputEvent() {
@@ -25,6 +25,11 @@ public class LeftClickGesture extends ValidatorGesture {
             mGestureStartX = mGestureEndX = CallbackBridge.mouseX;
             mGestureStartY = mGestureEndY = CallbackBridge.mouseY;
         }
+    }
+
+    @Override
+    protected int getDelayValue() {
+        return LauncherPreferences.PREF_LONGPRESS_TRIGGER;
     }
 
     @Override

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/mouse/RightClickGesture.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/mouse/RightClickGesture.java
@@ -6,12 +6,12 @@ import net.kdt.pojavlaunch.LwjglGlfwKeycode;
 
 import org.lwjgl.glfw.CallbackBridge;
 
-public class RightClickGesture extends ValidatorGesture{
+public class RightClickGesture extends ValidatorGesture {
     private boolean mGestureEnabled = true;
     private boolean mGestureValid = true;
     private float mGestureStartX, mGestureStartY, mGestureEndX, mGestureEndY;
     public RightClickGesture(Handler mHandler) {
-        super(mHandler, 150);
+        super(mHandler);
     }
 
     public final void inputEvent() {
@@ -27,6 +27,11 @@ public class RightClickGesture extends ValidatorGesture{
     public void setMotion(float deltaX, float deltaY) {
         mGestureEndX += deltaX;
         mGestureEndY += deltaY;
+    }
+
+    @Override
+    protected int getDelayValue() {
+        return 150;
     }
 
     @Override

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/mouse/ValidatorGesture.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/mouse/ValidatorGesture.java
@@ -9,16 +9,13 @@ import android.os.Handler;
 public abstract class ValidatorGesture implements Runnable{
     private final Handler mHandler;
     private boolean mGestureActive;
-    private final int mRequiredDuration;
 
     /**
      * @param mHandler the Handler that will be used for calling back the checkAndTrigger() method.
      *                 This Handler should run on the same thread as the callee of submit()/cancel()
-     * @param mRequiredDuration the duration after which the class will call checkAndTrigger().
      */
-    public ValidatorGesture(Handler mHandler, int mRequiredDuration) {
+    public ValidatorGesture(Handler mHandler) {
         this.mHandler = mHandler;
-        this.mRequiredDuration = mRequiredDuration;
     }
 
     /**
@@ -28,7 +25,7 @@ public abstract class ValidatorGesture implements Runnable{
      */
     public final boolean submit() {
         if(mGestureActive) return false;
-        mHandler.postDelayed(this, mRequiredDuration);
+        mHandler.postDelayed(this, getDelayValue());
         mGestureActive = true;
         return true;
     }
@@ -53,6 +50,11 @@ public abstract class ValidatorGesture implements Runnable{
         mGestureActive = false;
         onGestureCancelled(false);
     }
+
+    /**
+     * @return the duration after which the class will call checkAndTrigger().
+     */
+    protected abstract int getDelayValue();
 
     /**
      * This method will be called after mRequiredDuration milliseconds, if the gesture was not cancelled.


### PR DESCRIPTION
Use a separate Java method to get the long-press trigger delay instead of retrieving it during object creation.