### PR TITLE
fix[CustomSeekBarPreference]: incompatibility with TypedArray.close()…

### DIFF
--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/CustomSeekBarPreference.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/prefs/CustomSeekBarPreference.java
@@ -28,10 +28,10 @@ public class CustomSeekBarPreference extends SeekBarPreference {
     @SuppressLint("PrivateResource")
     public CustomSeekBarPreference(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
         super(context, attrs, defStyleAttr, defStyleRes);
-        try (TypedArray a = context.obtainStyledAttributes(
-                attrs, R.styleable.SeekBarPreference, defStyleAttr, defStyleRes)) {
-            mMin = a.getInt(R.styleable.SeekBarPreference_min, 0);
-        }
+        TypedArray a = context.obtainStyledAttributes(
+                attrs, R.styleable.SeekBarPreference, defStyleAttr, defStyleRes);
+        mMin = a.getInt(R.styleable.SeekBarPreference_min, 0);
+        a.recycle();
     }
 
     public CustomSeekBarPreference(Context context, AttributeSet attrs, int defStyleAttr) {


### PR DESCRIPTION
… on Android API lower than 31

Revert change from #6390 on this class
When I tested it on a device running Android 9, I had crashes when tried opening fragments containing CustomSeekBarPreference
Reverting this change fixed the problem

![image](https://github.com/user-attachments/assets/e9fa4785-c74b-4b80-9021-067ad17b5b34)
