### PR TITLE
Feat: move hooks into separate files, add extra hooks

### DIFF
--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/plugins/FFmpegPlugin.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/plugins/FFmpegPlugin.java
@@ -5,15 +5,21 @@ import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.util.Log;
 
+import java.io.File;
+
 public class FFmpegPlugin {
     public static boolean isAvailable = false;
     public static String libraryPath;
+    public static String executablePath;
     public static void discover(Context context) {
         PackageManager manager = context.getPackageManager();
         try {
             PackageInfo ffmpegPluginInfo = manager.getPackageInfo("net.kdt.pojavlaunch.ffmpeg", PackageManager.GET_SHARED_LIBRARY_FILES);
             libraryPath = ffmpegPluginInfo.applicationInfo.nativeLibraryDir;
-            isAvailable = true;
+            File ffmpegExecutable = new File(libraryPath, "libffmpeg.so");
+            executablePath = ffmpegExecutable.getAbsolutePath();
+            // Older plugin versions still have the old executable location
+            isAvailable = ffmpegExecutable.exists();
         }catch (Exception e) {
             Log.i("FFmpegPlugin", "Failed to discover plugin", e);
         }

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/JREUtils.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/JREUtils.java
@@ -368,7 +368,8 @@ public class JREUtils {
 
                 "-Dnet.minecraft.clientmodname=" + Tools.APP_NAME,
                 "-Dfml.earlyprogresswindow=false", //Forge 1.14+ workaround
-                "-Dloader.disable_forked_guis=true"
+                "-Dloader.disable_forked_guis=true",
+                "-Djdk.lang.Process.launchMechanism=FORK" // Default is POSIX_SPAWN which requires starting jspawnhelper, which doesn't work on Android
         ));
         if(LauncherPreferences.PREF_ARC_CAPES) {
             overridableArguments.add("-javaagent:"+new File(Tools.DIR_DATA,"arc_dns_injector/arc_dns_injector.jar").getAbsolutePath()+"=23.95.137.176");

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/JREUtils.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/JREUtils.java
@@ -215,7 +215,7 @@ public class JREUtils {
         envMap.put("LD_LIBRARY_PATH", LD_LIBRARY_PATH);
         envMap.put("PATH", jreHome + "/bin:" + Os.getenv("PATH"));
         if(FFmpegPlugin.isAvailable) {
-            envMap.put("PATH", FFmpegPlugin.libraryPath+":"+envMap.get("PATH"));
+            envMap.put("POJAV_FFMPEG_PATH", FFmpegPlugin.executablePath);
         }
 
         if(LOCAL_RENDERER != null) {

--- a/app_pojavlauncher/src/main/jni/Android.mk
+++ b/app_pojavlauncher/src/main/jni/Android.mk
@@ -46,6 +46,7 @@ LOCAL_SRC_FILES := \
     utils.c \
     stdio_is.c \
     java_exec_hooks.c \
+    lwjgl_dlopen_hook.c \
     driver_helper/nsbypass.c
 
 ifeq ($(TARGET_ARCH_ABI),arm64-v8a)

--- a/app_pojavlauncher/src/main/jni/Android.mk
+++ b/app_pojavlauncher/src/main/jni/Android.mk
@@ -45,6 +45,7 @@ LOCAL_SRC_FILES := \
     jre_launcher.c \
     utils.c \
     stdio_is.c \
+    java_exec_hooks.c \
     driver_helper/nsbypass.c
 
 ifeq ($(TARGET_ARCH_ABI),arm64-v8a)

--- a/app_pojavlauncher/src/main/jni/egl_bridge.c
+++ b/app_pojavlauncher/src/main/jni/egl_bridge.c
@@ -258,14 +258,18 @@ EXTERNAL_API void* pojavCreateContext(void* contextSrc) {
     return br_init_context((basic_render_window_t*)contextSrc);
 }
 
-EXTERNAL_API JNIEXPORT jlong JNICALL
-Java_org_lwjgl_vulkan_VK_getVulkanDriverHandle(ABI_COMPAT JNIEnv *env, ABI_COMPAT jclass thiz) {
-    printf("EGLBridge: LWJGL-side Vulkan loader requested the Vulkan handle\n");
-    // The code below still uses the env var because
+void* maybe_load_vulkan() {
+    // We use the env var because
     // 1. it's easier to do that
     // 2. it won't break if something will try to load vulkan and osmesa simultaneously
     if(getenv("VULKAN_PTR") == NULL) load_vulkan();
-    return strtoul(getenv("VULKAN_PTR"), NULL, 0x10);
+    return (void*) strtoul(getenv("VULKAN_PTR"), NULL, 0x10);
+}
+
+EXTERNAL_API JNIEXPORT jlong JNICALL
+Java_org_lwjgl_vulkan_VK_getVulkanDriverHandle(ABI_COMPAT JNIEnv *env, ABI_COMPAT jclass thiz) {
+    printf("EGLBridge: LWJGL-side Vulkan loader requested the Vulkan handle\n");
+    return (jlong) maybe_load_vulkan();
 }
 
 EXTERNAL_API void pojavSwapInterval(int interval) {

--- a/app_pojavlauncher/src/main/jni/input_bridge_v3.c
+++ b/app_pojavlauncher/src/main/jni/input_bridge_v3.c
@@ -229,47 +229,6 @@ void sendData(int type, int i1, int i2, int i3, int i4) {
 }
 
 /**
- * Basically a verbatim implementation of ndlopen(), found at
- * https://github.com/PojavLauncherTeam/lwjgl3/blob/3.3.1/modules/lwjgl/core/src/generated/c/linux/org_lwjgl_system_linux_DynamicLinkLoader.c#L11
- * The idea is that since, on Android 10 and earlier, the linker doesn't really do namespace nesting.
- * It is not a problem as most of the libraries are in the launcher path, but when you try to run
- * VulkanMod which loads shaderc outside of the default jni libs directory through this method,
- * it can't load it because the path is not in the allowed paths for the anonymous namesapce.
- * This method fixes the issue by being in libpojavexec, and thus being in the classloader namespace
- */
-jlong ndlopen_bugfix(__attribute__((unused)) JNIEnv *env,
-                     __attribute__((unused)) jclass class,
-                     jlong filename_ptr,
-                     jint jmode) {
-    const char* filename = (const char*) filename_ptr;
-    int mode = (int)jmode;
-    return (jlong) dlopen(filename, mode);
-}
-
-/**
- * Install the linker bug mitigation for Android 10 and lower. Fixes VulkanMod crashing on these
- * Android versions due to missing namespace nesting.
- */
-void installLinkerBugMitigation() {
-    if(android_get_device_api_level() >= 30) return;
-    __android_log_print(ANDROID_LOG_INFO, "Api29LinkerFix", "API < 30 detected, installing linker bug mitigation");
-    JNIEnv* env = pojav_environ->runtimeJNIEnvPtr_JRE;
-    jclass dynamicLinkLoader = (*env)->FindClass(env, "org/lwjgl/system/linux/DynamicLinkLoader");
-    if(dynamicLinkLoader == NULL) {
-        __android_log_print(ANDROID_LOG_ERROR, "Api29LinkerFix", "Failed to find the target class");
-        (*env)->ExceptionClear(env);
-        return;
-    }
-    JNINativeMethod ndlopenMethod[] = {
-            {"ndlopen", "(JI)J", &ndlopen_bugfix}
-    };
-    if((*env)->RegisterNatives(env, dynamicLinkLoader, ndlopenMethod, 1) != 0) {
-        __android_log_print(ANDROID_LOG_ERROR, "Api29LinkerFix", "Failed to register the bugfix method");
-        (*env)->ExceptionClear(env);
-    }
-}
-
-/**
  * This function is meant as a substitute for SharedLibraryUtil.getLibraryPath() that just returns 0
  * (thus making the parent Java function return null). This is done to avoid using the LWJGL's default function,
  * which will hang the crappy EMUI linker by dlopen()ing inside of dl_iterate_phdr().

--- a/app_pojavlauncher/src/main/jni/input_bridge_v3.c
+++ b/app_pojavlauncher/src/main/jni/input_bridge_v3.c
@@ -57,7 +57,7 @@ jint JNI_OnLoad(JavaVM* vm, __attribute__((unused)) void* reserved) {
         jobject mouseDownBufferJ = (*pojav_environ->runtimeJNIEnvPtr_JRE)->GetStaticObjectField(pojav_environ->runtimeJNIEnvPtr_JRE, pojav_environ->vmGlfwClass, field_mouseDownBuffer);
         pojav_environ->mouseDownBuffer = (*pojav_environ->runtimeJNIEnvPtr_JRE)->GetDirectBufferAddress(pojav_environ->runtimeJNIEnvPtr_JRE, mouseDownBufferJ);
         hookExec();
-        installLinkerBugMitigation();
+        installLwjglDlopenHook();
         installEMUIIteratorMititgation();
     }
 

--- a/app_pojavlauncher/src/main/jni/java_exec_hooks.c
+++ b/app_pojavlauncher/src/main/jni/java_exec_hooks.c
@@ -52,7 +52,7 @@ static jint hooked_ProcessImpl_forkAndExec(JNIEnv *env, jobject process, jint mo
 
     if(strcmp(prog_basename, "xdg-open") == 0) {
         // When invoking xdg-open, send the open URL into Android
-        Java_org_lwjgl_glfw_CallbackBridge_nativeClipboard(env, NULL, /* CLIPBOARD_OPEN */ 2002, argBlock);
+        Java_org_lwjgl_glfw_CallbackBridge_nativeClipboard(env, NULL, CLIPBOARD_OPEN, argBlock);
         return 0;
     }else if(strcmp(prog_basename, "ffmpeg") == 0) {
         // When invoking ffmpeg, always replace the program path with the path to ffmpeg from the plugin.

--- a/app_pojavlauncher/src/main/jni/java_exec_hooks.c
+++ b/app_pojavlauncher/src/main/jni/java_exec_hooks.c
@@ -63,7 +63,6 @@ static jint hooked_ProcessImpl_forkAndExec(JNIEnv *env, jobject process, jint mo
         // Also add LD_LIBRARY_PATH and PATH for the lib in order to override the ones from the launcher, since
         // they may interfere with ffmpeg dependencies.
         const char* ffmpeg_path = getenv("POJAV_FFMPEG_PATH");
-        prog = NULL;
         if(ffmpeg_path != NULL) {
             replaceLibPathInEnvBlock(env, &envBlock, &envc, dirname(ffmpeg_path));
             prog = stringToBytes(env, ffmpeg_path);

--- a/app_pojavlauncher/src/main/jni/java_exec_hooks.c
+++ b/app_pojavlauncher/src/main/jni/java_exec_hooks.c
@@ -1,0 +1,90 @@
+//
+// Created by maks on 05.01.2025.
+//
+
+#include <jni.h>
+#include <libgen.h>
+#include <string.h>
+#include <stdlib.h>
+#include <dlfcn.h>
+
+#include <environ/environ.h>
+#include <android/log.h>
+#include <utils.h>
+
+static jint (*orig_ProcessImpl_forkAndExec)(JNIEnv *env, jobject process, jint mode, jbyteArray helperpath, jbyteArray prog, jbyteArray argBlock, jint argc, jbyteArray envBlock, jint envc, jbyteArray dir, jintArray std_fds, jboolean redirectErrorStream);
+
+// Turn a C-style string into a Java byte array
+static jbyteArray stringToBytes(JNIEnv *env, const char* string) {
+    const jsize string_data_len = (jsize)(strlen(string) + 1);
+    jbyteArray result = (*env)->NewByteArray(env, (jsize)string_data_len);
+    (*env)->SetByteArrayRegion(env, result, 0, (jsize)string_data_len, (const jbyte*) string);
+    return result;
+}
+
+// Replace the env block with the one that has the desired LD_LIBRARY_PATH/PATH.
+// (Due to my laziness this ignores the current contents of the block)
+static void replaceLibPathInEnvBlock(JNIEnv *env, jbyteArray* envBlock, jint* envc, const char* directory) {
+    static bool env_block_replacement_warning = false;
+    if(*envBlock != NULL && !env_block_replacement_warning) {
+        printf("exec_hooks WARN: replaceLibPathInEnvBlock does not preserve original env. Please notify PojavLauncherTeam if you need that feature\n");
+        env_block_replacement_warning = true;
+    }
+    char envStr[1024];
+    jsize new_envl = snprintf(envStr, sizeof(envStr) / sizeof(char), "LD_LIBRARY_PATH=%s%cPATH=%s", directory, 0 ,directory) + 1;
+    jbyteArray newBlock = (*env)->NewByteArray(env, new_envl);
+    (*env)->SetByteArrayRegion(env, newBlock, 0, new_envl, (jbyte*) envStr);
+    *envBlock = newBlock;
+    *envc = 2;
+}
+
+/**
+ * Hooked version of java.lang.UNIXProcess.forkAndExec()
+ * which is used to handle the "open" command and "ffmpeg" invocations
+ */
+static jint hooked_ProcessImpl_forkAndExec(JNIEnv *env, jobject process, jint mode, jbyteArray helperpath, jbyteArray prog, jbyteArray argBlock, jint argc, jbyteArray envBlock, jint envc, jbyteArray dir, jintArray std_fds, jboolean redirectErrorStream) {
+    const char *pProg = (char *)((*env)->GetByteArrayElements(env, prog, NULL));
+    const char* pProgBaseName = basename(pProg);
+    const size_t basename_len = strlen(pProgBaseName);
+    char prog_basename[basename_len];
+    memcpy(&prog_basename, pProgBaseName, basename_len + 1);
+    (*env)->ReleaseByteArrayElements(env, prog, (jbyte *)pProg, 0);
+
+    if(strcmp(prog_basename, "xdg-open") == 0) {
+        // When invoking xdg-open, send the open URL into Android
+        Java_org_lwjgl_glfw_CallbackBridge_nativeClipboard(env, NULL, /* CLIPBOARD_OPEN */ 2002, argBlock);
+        return 0;
+    }else if(strcmp(prog_basename, "ffmpeg") == 0) {
+        // When invoking ffmpeg, always replace the program path with the path to ffmpeg from the plugin.
+        // This allows us to replace the executable name, which is needed because android doesn't allow
+        // us to put files that don't start with "lib" and end with ".so" into folders that we can execute
+        // from
+
+        // Also add LD_LIBRARY_PATH and PATH for the lib in order to override the ones from the launcher, since
+        // they may interfere with ffmpeg dependencies.
+        const char* ffmpeg_path = getenv("POJAV_FFMPEG_PATH");
+        prog = NULL;
+        if(ffmpeg_path != NULL) {
+            replaceLibPathInEnvBlock(env, &envBlock, &envc, dirname(ffmpeg_path));
+            prog = stringToBytes(env, ffmpeg_path);
+        }
+    }
+    return orig_ProcessImpl_forkAndExec(env, process, mode, helperpath, prog, argBlock, argc, envBlock, envc, dir, std_fds, redirectErrorStream);
+}
+
+// Hook the forkAndExec method in the Java runtime for custom executable overriding.
+void hookExec() {
+    jclass cls;
+    orig_ProcessImpl_forkAndExec = dlsym(RTLD_DEFAULT, "Java_java_lang_UNIXProcess_forkAndExec");
+    if (!orig_ProcessImpl_forkAndExec) {
+        orig_ProcessImpl_forkAndExec = dlsym(RTLD_DEFAULT, "Java_java_lang_ProcessImpl_forkAndExec");
+        cls = (*pojav_environ->runtimeJNIEnvPtr_JRE)->FindClass(pojav_environ->runtimeJNIEnvPtr_JRE, "java/lang/ProcessImpl");
+    } else {
+        cls = (*pojav_environ->runtimeJNIEnvPtr_JRE)->FindClass(pojav_environ->runtimeJNIEnvPtr_JRE, "java/lang/UNIXProcess");
+    }
+    JNINativeMethod methods[] = {
+            {"forkAndExec", "(I[B[B[BI[BI[B[IZ)I", (void *)&hooked_ProcessImpl_forkAndExec}
+    };
+    (*pojav_environ->runtimeJNIEnvPtr_JRE)->RegisterNatives(pojav_environ->runtimeJNIEnvPtr_JRE, cls, methods, 1);
+    printf("Registered forkAndExec\n");
+}

--- a/app_pojavlauncher/src/main/jni/lwjgl_dlopen_hook.c
+++ b/app_pojavlauncher/src/main/jni/lwjgl_dlopen_hook.c
@@ -45,8 +45,8 @@ static jlong ndlopen_bugfix(__attribute__((unused)) JNIEnv *env,
 /**
  * Install the LWJGL dlopen hook. This allows us to mitigate linker bugs and add custom library overrides.
  */
-void installLinkerBugMitigation() {
-    __android_log_print(ANDROID_LOG_INFO, "LwjglLinkerHook", "API < 30 detected, installing linker bug mitigation");
+void installLwjglDlopenHook() {
+    __android_log_print(ANDROID_LOG_INFO, "LwjglLinkerHook", "Installing LWJGL dlopen() hook");
     JNIEnv* env = pojav_environ->runtimeJNIEnvPtr_JRE;
     jclass dynamicLinkLoader = (*env)->FindClass(env, "org/lwjgl/system/linux/DynamicLinkLoader");
     if(dynamicLinkLoader == NULL) {

--- a/app_pojavlauncher/src/main/jni/lwjgl_dlopen_hook.c
+++ b/app_pojavlauncher/src/main/jni/lwjgl_dlopen_hook.c
@@ -1,0 +1,64 @@
+//
+// Created by maks on 06.01.2025.
+//
+
+#include <android/api-level.h>
+#include <android/log.h>
+#include <jni.h>
+
+#include <environ/environ.h>
+
+#include <dlfcn.h>
+#include <string.h>
+#include <stdlib.h>
+
+extern void* maybe_load_vulkan();
+
+/**
+ * Basically a verbatim implementation of ndlopen(), found at
+ * https://github.com/PojavLauncherTeam/lwjgl3/blob/3.3.1/modules/lwjgl/core/src/generated/c/linux/org_lwjgl_system_linux_DynamicLinkLoader.c#L11
+ * but with our own additions for stuff like vulkanmod.
+ */
+static jlong ndlopen_bugfix(__attribute__((unused)) JNIEnv *env,
+                     __attribute__((unused)) jclass class,
+                     jlong filename_ptr,
+                     jint jmode) {
+    const char* filename = (const char*) filename_ptr;
+
+    // Oveeride vulkan loading to let us load vulkan ourselves
+    if(strstr(filename, "libvulkan.so") == filename) {
+        printf("LWJGL linkerhook: replacing load for libvulkan.so with custom driver\n");
+        return (jlong) maybe_load_vulkan();
+    }
+
+    // This hook also serves the task of mitigating a bug: the idea is that since, on Android 10 and
+    // earlier, the linker doesn't really do namespace nesting.
+    // It is not a problem as most of the libraries are in the launcher path, but when you try to run
+    // VulkanMod which loads shaderc outside of the default jni libs directory through this method,
+    // it can't load it because the path is not in the allowed paths for the anonymous namesapce.
+    // This method fixes the issue by being in libpojavexec, and thus being in the classloader namespace
+
+    int mode = (int)jmode;
+    return (jlong) dlopen(filename, mode);
+}
+
+/**
+ * Install the LWJGL dlopen hook. This allows us to mitigate linker bugs and add custom library overrides.
+ */
+void installLinkerBugMitigation() {
+    __android_log_print(ANDROID_LOG_INFO, "LwjglLinkerHook", "API < 30 detected, installing linker bug mitigation");
+    JNIEnv* env = pojav_environ->runtimeJNIEnvPtr_JRE;
+    jclass dynamicLinkLoader = (*env)->FindClass(env, "org/lwjgl/system/linux/DynamicLinkLoader");
+    if(dynamicLinkLoader == NULL) {
+        __android_log_print(ANDROID_LOG_ERROR, "LwjglLinkerHook", "Failed to find the target class");
+        (*env)->ExceptionClear(env);
+        return;
+    }
+    JNINativeMethod ndlopenMethod[] = {
+            {"ndlopen", "(JI)J", &ndlopen_bugfix}
+    };
+    if((*env)->RegisterNatives(env, dynamicLinkLoader, ndlopenMethod, 1) != 0) {
+        __android_log_print(ANDROID_LOG_ERROR, "LwjglLinkerHook", "Failed to register the hooked method");
+        (*env)->ExceptionClear(env);
+    }
+}

--- a/app_pojavlauncher/src/main/jni/utils.h
+++ b/app_pojavlauncher/src/main/jni/utils.h
@@ -2,7 +2,9 @@
 
 #include <stdbool.h>
 
-
+#define CLIPBOARD_COPY 2000
+#define CLIPBOARD_PASTE 2001
+#define CLIPBOARD_OPEN 2002
 
 char** convert_to_char_array(JNIEnv *env, jobjectArray jstringArray);
 jobjectArray convert_from_char_array(JNIEnv *env, char **charArray, int num_rows);
@@ -10,7 +12,7 @@ void free_char_array(JNIEnv *env, jobjectArray jstringArray, const char **charAr
 jstring convertStringJVM(JNIEnv* srcEnv, JNIEnv* dstEnv, jstring srcStr);
 
 void hookExec();
-void installLinkerBugMitigation();
+void installLwjglDlopenHook();
 void installEMUIIteratorMititgation();
 JNIEXPORT jstring JNICALL Java_org_lwjgl_glfw_CallbackBridge_nativeClipboard(JNIEnv* env, jclass clazz, jint action, jbyteArray copySrc);
 


### PR DESCRIPTION
This PR:
- Moves hooks for JNI methods into separate files
- Add an exec hook for FFmpeg for better ReplayMod compatibility
- Changes the ffmpeg executable name to allow building FFmpeg plugin APK in release mode
- Add a dlopen hook for libvulkan to allow usage of custom drivers with LWJGL Vulkan