### PR TITLE
fix(side dialog): crash when deflating twice in quick succession

### DIFF
--- a/app_pojavlauncher/src/main/java/com/kdt/SideDialogView.java
+++ b/app_pojavlauncher/src/main/java/com/kdt/SideDialogView.java
@@ -132,6 +132,9 @@ public abstract class SideDialogView {
             return;
         }
 
+        mSideDialogAnimator.removeAllUpdateListeners();
+        mSideDialogAnimator.removeAllListeners();
+
         mParent.removeView(mDialogLayout);
         mIsInstantiated = false;
 
@@ -212,7 +215,6 @@ public abstract class SideDialogView {
             mSideDialogAnimator.addListener(new AnimatorListenerAdapter() {
                 @Override
                 public void onAnimationEnd(Animator animation) {
-                    mSideDialogAnimator.removeListener(this);
                     deflateLayout();
                 }
             });


### PR DESCRIPTION
Fix an issue where we referenced a variable after destroying the ref in the side layout.