### PR TITLE
Fix[DownloadUtils]: Set Read Timeout Duration

### DIFF
--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/DownloadUtils.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/DownloadUtils.java
@@ -37,8 +37,6 @@ public class DownloadUtils {
             }
             is = conn.getInputStream();
             IOUtils.copy(is, os);
-        } catch (SocketTimeoutException e) {
-            throw new IOException("Download timed out: " + url, e);
         } catch (IOException e) {
             throw new IOException("Unable to download from " + url, e);
         } finally {
@@ -87,8 +85,8 @@ public class DownloadUtils {
                 monitor.updateProgress(overall, length);
             }
             conn.disconnect();
-        } catch (SocketTimeoutException e) {
-            throw new IOException("Download timed out: " + urlInput, e);
+        } catch (IOException e) {
+            throw new IOException("Unable to download from " + urlInput, e);
         }
     }
 


### PR DESCRIPTION
Pojav has not set a timeout for downloading files, which results in situations where file downloads do not throw an exception or terminate even after timing out.