### PR TITLE
Add the option to send first character of Control's name as keyChar on Control press.

### DIFF
--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/ControlData.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/ControlData.java
@@ -65,6 +65,7 @@ public class ControlData {
     public boolean isSwipeable;
     public boolean displayInGame;
     public boolean displayInMenu;
+    public boolean sendChar;
     private float width;         //Dp instead of Px now
     private float height;        //Dp instead of Px now
 
@@ -112,7 +113,7 @@ public class ControlData {
         this(name, keycodes, dynamicX, dynamicY, width, height, isToggle, 1, 0x4D000000, 0xFFFFFFFF, 0, 0, true, true, false, false);
     }
 
-    public ControlData(String name, int[] keycodes, String dynamicX, String dynamicY, float width, float height, boolean isToggle, float opacity, int bgColor, int strokeColor, float strokeWidth, float cornerRadius, boolean displayInGame, boolean displayInMenu, boolean isSwipable, boolean mousePassthrough) {
+    public ControlData(String name, int[] keycodes, String dynamicX, String dynamicY, float width, float height, boolean isToggle, float opacity, int bgColor, int strokeColor, float strokeWidth, float cornerRadius, boolean displayInGame, boolean displayInMenu, boolean sendChar, boolean isSwipable, boolean mousePassthrough) {
         this.name = name;
         this.keycodes = inflateKeycodeArray(keycodes);
         this.dynamicX = dynamicX;
@@ -127,6 +128,7 @@ public class ControlData {
         this.cornerRadius = cornerRadius;
         this.displayInGame = displayInGame;
         this.displayInMenu = displayInMenu;
+        this.sendChar = sendChar;
         this.isSwipeable = isSwipable;
         this.passThruEnabled = mousePassthrough;
     }
@@ -148,6 +150,7 @@ public class ControlData {
                 controlData.cornerRadius,
                 controlData.displayInGame,
                 controlData.displayInMenu,
+                controlData.sendChar,
                 controlData.isSwipeable,
                 controlData.passThruEnabled
         );

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/buttons/ControlButton.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/customcontrols/buttons/ControlButton.java
@@ -191,7 +191,11 @@ public class ControlButton extends TextView implements ControlInterface {
         setActivated(isDown);
         for(int keycode : mProperties.keycodes){
             if(keycode >= GLFW_KEY_UNKNOWN){
-                sendKeyPress(keycode, CallbackBridge.getCurrentMods(), isDown);
+                if(mProperties.sendChar) {
+                    sendKeyPress(keyCode, mProperties.name.charAt(0), 0, modifiers, status);
+                } else {
+                    sendKeyPress(keycode, CallbackBridge.getCurrentMods(), isDown);
+                }
                 CallbackBridge.setModifiers(keycode, isDown);
             }else{
                 Log.i("punjabilauncher", "sendSpecialKey("+keycode+","+isDown+")");


### PR DESCRIPTION
I was using PoJav to play Minecraft on a server, and couldn't find a way to bind a Control to type '/' (or any characters) in the chat. Looking at the code I see the reason for this, the control only sends keyCodes and no keyChars. I then had the idea to add a toggle option to send a character when the button is pressed. To avoid cumbersome additions to the control editor, I suggest using mProperties.name.charAt(0). See code in PR for example implementation.