### PR TITLE
Fix LTW being missing when building

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -27,16 +27,10 @@ jobs:
           java-version: '8'
 
       - name: Get LTW
-        uses: dawidd6/action-download-artifact@v2
-        continue-on-error: true
-        with:
-          github_token: ${{secrets.LTW_CLONER_SECRET}}
-          repo: PojavLauncherTeam/BigTinyWrapper
-          workflow: android.yml
-          workflow_conclusion: success
-          name: output-aar
-          path: app_pojavlauncher/libs
-          allow_forks: false
+        run: |
+          apt update && apt install wget
+          cd app_pojavlauncher/libs
+          wget https://github.com/PojavLauncherTeam/LTW/releases/latest/download/ltw-release.aar
 
       - name: Get JRE 8
         uses: dawidd6/action-download-artifact@v2


### PR DESCRIPTION
I forked the public LTW repo so even if the main repo gets deleted, mine will still exist and used a release so we don't have to worry about artifact expiry. 

I got too lazy to set up automatic release upload for total trust. md5sum it yourself paranoid people.