### PR TITLE
feat: demo mode when using local account

### DIFF
--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/LauncherActivity.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/LauncherActivity.java
@@ -125,6 +125,14 @@ public class LauncherActivity extends BaseActivity {
         }
         String normalizedVersionId = AsyncMinecraftDownloader.normalizeVersionId(prof.lastVersionId);
         JMinecraftVersionList.Version mcVersion = AsyncMinecraftDownloader.getListedVersion(normalizedVersionId);
+
+        // Do not load when is a modded version or older than minecraft 1.3
+        if((mcVersion == null || AsyncMinecraftDownloader.isOlderThan13(mcVersion.releaseTime))
+                && PojavProfile.getCurrentProfileContent(this, null).isLocal()){
+            Toast.makeText(this, R.string.toast_not_available_demo, Toast.LENGTH_LONG).show();
+            return false;
+        }
+
         new MinecraftDownloader().start(
                 this,
                 mcVersion,

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/Tools.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/Tools.java
@@ -506,13 +506,13 @@ public final class Tools {
             }
         }
 
-        return JSONUtils.insertJSONValueList(
-                splitAndFilterEmpty(
-                        versionInfo.minecraftArguments == null ?
-                                fromStringArray(minecraftArgs.toArray(new String[0])):
-                                versionInfo.minecraftArguments
-                ), varArgMap
-        );
+        String mcArguments = versionInfo.minecraftArguments == null ?
+                fromStringArray(minecraftArgs.toArray(new String[0])):
+                versionInfo.minecraftArguments;
+
+        if(profile.isLocal()) mcArguments += " --demo";
+
+        return JSONUtils.insertJSONValueList(splitAndFilterEmpty(mcArguments), varArgMap);
     }
 
     public static String fromStringArray(String[] strArr) {

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/fragments/ProfileTypeSelectFragment.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/fragments/ProfileTypeSelectFragment.java
@@ -2,11 +2,13 @@ package net.kdt.pojavlaunch.fragments;
 
 import android.os.Bundle;
 import android.view.View;
+import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 
+import net.kdt.pojavlaunch.PojavProfile;
 import net.kdt.pojavlaunch.R;
 import net.kdt.pojavlaunch.Tools;
 
@@ -25,17 +27,25 @@ public class ProfileTypeSelectFragment extends Fragment {
         // NOTE: Special care needed! If you wll decide to add these to the back stack, please read
         // the comment in FabricInstallFragment.onDownloadFinished() and amend the code
         // in FabricInstallFragment.onDownloadFinished() and ModVersionListFragment.onDownloadFinished()
-        view.findViewById(R.id.optifine_profile).setOnClickListener(v -> Tools.swapFragment(requireActivity(), OptiFineInstallFragment.class,
-                OptiFineInstallFragment.TAG, null));
+        view.findViewById(R.id.optifine_profile).setOnClickListener(v ->
+                tryInstall(OptiFineInstallFragment.class, OptiFineInstallFragment.TAG));
         view.findViewById(R.id.modded_profile_fabric).setOnClickListener((v)->
-                Tools.swapFragment(requireActivity(), FabricInstallFragment.class, FabricInstallFragment.TAG, null));
+                tryInstall(FabricInstallFragment.class, FabricInstallFragment.TAG));
         view.findViewById(R.id.modded_profile_forge).setOnClickListener((v)->
-                Tools.swapFragment(requireActivity(), ForgeInstallFragment.class, ForgeInstallFragment.TAG, null));
+                tryInstall(ForgeInstallFragment.class, ForgeInstallFragment.TAG));
         view.findViewById(R.id.modded_profile_modpack).setOnClickListener((v)->
-                Tools.swapFragment(requireActivity(), SearchModFragment.class, SearchModFragment.TAG, null));
+                tryInstall(SearchModFragment.class, SearchModFragment.TAG));
         view.findViewById(R.id.modded_profile_quilt).setOnClickListener((v)->
-                Tools.swapFragment(requireActivity(), QuiltInstallFragment.class, QuiltInstallFragment.TAG, null));
+                tryInstall(QuiltInstallFragment.class, QuiltInstallFragment.TAG));
         view.findViewById(R.id.modded_profile_bta).setOnClickListener((v)->
-                Tools.swapFragment(requireActivity(), BTAInstallFragment.class, BTAInstallFragment.TAG, null));
+                tryInstall(BTAInstallFragment.class, BTAInstallFragment.TAG));
+    }
+
+    private void tryInstall(Class<? extends Fragment> fragmentClass, String tag){
+        if(PojavProfile.getCurrentProfileContent(requireContext(), null).isLocal()){
+            Toast.makeText(requireContext(), R.string.toast_not_available_demo, Toast.LENGTH_LONG).show();
+        } else {
+            Tools.swapFragment(requireActivity(), fragmentClass, tag, null);
+        }
     }
 }

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/tasks/AsyncMinecraftDownloader.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/tasks/AsyncMinecraftDownloader.java
@@ -5,6 +5,12 @@ import net.kdt.pojavlaunch.extra.ExtraConstants;
 import net.kdt.pojavlaunch.extra.ExtraCore;
 import net.kdt.pojavlaunch.value.launcherprofiles.MinecraftProfile;
 
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+import java.util.TimeZone;
+
 public class AsyncMinecraftDownloader {
     public static String normalizeVersionId(String versionString) {
         JMinecraftVersionList versionList = (JMinecraftVersionList) ExtraCore.getValue(ExtraConstants.RELEASE_TABLE);
@@ -21,6 +27,29 @@ public class AsyncMinecraftDownloader {
             if(version.id.equals(normalizedVersionString)) return version;
         }
         return null;
+    }
+
+
+    /**
+     * Minecraft has implemented demo mode in version 1.3, so this method return if the release time of a version is older than the 1.3 release
+     *
+     * @param releaseTimeString Version Release Time to check if is older than Minecraft 1.3 release time
+     * @return {@code true} if the version is older than 1.3, {@code false} otherwise
+     */
+    public static boolean isOlderThan13(String releaseTimeString) {
+        // change "+00:00" to "+0000" due API level
+        releaseTimeString = releaseTimeString.replaceFirst("([+-]\\d{2}):(\\d{2})", "$1$2");
+
+        SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ", Locale.US);
+        format.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        try {
+            Date releaseTime = format.parse(releaseTimeString);
+            Date v13ReleaseTime = format.parse("2012-07-25T22:00:00+0000");
+            return releaseTime == null || releaseTime.before(v13ReleaseTime);
+        } catch (ParseException e) {
+            return true;
+        }
     }
 
     public interface DoneListener{

--- a/app_pojavlauncher/src/main/res/values/strings.xml
+++ b/app_pojavlauncher/src/main/res/values/strings.xml
@@ -430,4 +430,5 @@
     <string name="bta_installer_untested_versions">Untested BTA versions</string>
     <string name="bta_installer_nightly_versions">Nightly BTA versions</string>
     <string name="newdl_extracting_native_libraries">Extracting native libraries (%d/%d)</string>
+    <string name="toast_not_available_demo">This version is not available in demo mode</string>
 </resources>


### PR DESCRIPTION
Apply minecraft's “--demo” arg when the current account is local
Do not allow playing when the release date is earlier than minecraft version 1.3 (the version that implemented demo mode)
Do not allow the installation of custom versions (such as forge, optifine, fabric, and others)