### PR TITLE
fix[demo]: being able to access the hidden demo folder

### DIFF
--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/fragments/MainMenuFragment.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/fragments/MainMenuFragment.java
@@ -65,6 +65,7 @@ public class MainMenuFragment extends Fragment {
         mShareLogsButton.setOnClickListener((v) -> shareLog(requireContext()));
 
         mOpenDirectoryButton.setOnClickListener((v)-> {
+            Tools.switchDemo(Tools.isDemoProfile(v.getContext())); // avoid switching accounts being able to access
             if(Tools.isDemoProfile(v.getContext())){
                 Toast.makeText(v.getContext(), R.string.toast_not_available_demo, Toast.LENGTH_LONG).show();
                 return;

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/fragments/MainMenuFragment.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/fragments/MainMenuFragment.java
@@ -64,7 +64,14 @@ public class MainMenuFragment extends Fragment {
 
         mShareLogsButton.setOnClickListener((v) -> shareLog(requireContext()));
 
-        mOpenDirectoryButton.setOnClickListener((v)-> openPath(v.getContext(), getCurrentProfileDirectory(), false));
+        mOpenDirectoryButton.setOnClickListener((v)-> {
+            if(Tools.isDemoProfile(v.getContext())){
+                Toast.makeText(v.getContext(), R.string.toast_not_available_demo, Toast.LENGTH_LONG).show();
+                return;
+            }
+
+            openPath(v.getContext(), getCurrentProfileDirectory(), false);
+        });
 
 
         mNewsButton.setOnLongClickListener((v)->{


### PR DESCRIPTION
I forgot to block the function of the button to open the game directory, as it directs to the profile folder, and thus makes it possible to access the hidden folder easily.